### PR TITLE
[FIN-70] 닉네임, 블로그이름, 블로그 URL 중복 검사

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/authentication/oauth/google/dto/request/GoogleAccessTokenRequest.java
+++ b/src/main/java/kr/co/finote/backend/global/authentication/oauth/google/dto/request/GoogleAccessTokenRequest.java
@@ -1,4 +1,4 @@
-package kr.co.finote.backend.global.authentication.oauth.google;
+package kr.co.finote.backend.global.authentication.oauth.google.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
@@ -7,7 +7,7 @@ import lombok.*;
 @NoArgsConstructor
 @Getter
 @Setter
-public class GoogleAccessTokenDto {
+public class GoogleAccessTokenRequest {
 
     @JsonProperty("access_token")
     private String accessToken;

--- a/src/main/java/kr/co/finote/backend/global/authentication/oauth/google/dto/response/GoogleLoginResponse.java
+++ b/src/main/java/kr/co/finote/backend/global/authentication/oauth/google/dto/response/GoogleLoginResponse.java
@@ -1,4 +1,4 @@
-package kr.co.finote.backend.global.authentication.oauth.google;
+package kr.co.finote.backend.global.authentication.oauth.google.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -6,14 +6,14 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class GoogleLoginResponseDto {
+public class GoogleLoginResponse {
 
     private String accessToken;
     private String refreshToken;
     private Boolean newUser;
 
     @Builder
-    public GoogleLoginResponseDto(String accessToken, String refreshToken, Boolean newUser) {
+    public GoogleLoginResponse(String accessToken, String refreshToken, Boolean newUser) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
         this.newUser = newUser;

--- a/src/main/java/kr/co/finote/backend/global/authentication/oauth/google/dto/response/GoogleOauthUserInfoResponse.java
+++ b/src/main/java/kr/co/finote/backend/global/authentication/oauth/google/dto/response/GoogleOauthUserInfoResponse.java
@@ -1,4 +1,4 @@
-package kr.co.finote.backend.global.authentication.oauth.google;
+package kr.co.finote.backend.global.authentication.oauth.google.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -10,7 +10,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
-public class GoogleOauthUserInfoDto {
+public class GoogleOauthUserInfoResponse {
 
     private String id;
     private String email;

--- a/src/main/java/kr/co/finote/backend/src/blog/api/UsersBlogApi.java
+++ b/src/main/java/kr/co/finote/backend/src/blog/api/UsersBlogApi.java
@@ -21,24 +21,24 @@ public class UsersBlogApi {
     private final UsersBlogService usersBlogService;
 
     @PostMapping(value = "/validation/blog-name", consumes = APPLICATION_JSON_VALUE)
-    public Map<String, String> validateBlogName(@RequestBody Map<String, String> requestData) {
+    public Map<String, Boolean> validateBlogName(@RequestBody Map<String, String> requestData) {
         String blogName = requestData.get("blogName");
 
         boolean isDuplicated = usersBlogService.duplicateBlogName(blogName);
 
-        Map<String, String> map = new HashMap<>();
-        map.put("isDuplicated", Boolean.toString(isDuplicated));
+        Map<String, Boolean> map = new HashMap<>();
+        map.put("isDuplicated", isDuplicated);
         return map;
     }
 
     @PostMapping(value = "/validation/blog-url", consumes = APPLICATION_JSON_VALUE)
-    public Map<String, String> validateBlogUrl(@RequestBody Map<String, String> requestData) {
+    public Map<String, Boolean> validateBlogUrl(@RequestBody Map<String, String> requestData) {
         String blogUrl = requestData.get("blogUrl");
 
         boolean isDuplicated = usersBlogService.duplicateBlogUrl(blogUrl);
 
-        Map<String, String> map = new HashMap<>();
-        map.put("isDuplicated", Boolean.toString(isDuplicated));
+        Map<String, Boolean> map = new HashMap<>();
+        map.put("isDuplicated", isDuplicated);
         return map;
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/blog/api/UsersBlogApi.java
+++ b/src/main/java/kr/co/finote/backend/src/blog/api/UsersBlogApi.java
@@ -1,0 +1,44 @@
+package kr.co.finote.backend.src.blog.api;
+
+import static org.springframework.http.MediaType.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import kr.co.finote.backend.src.blog.service.UsersBlogService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/blogs")
+public class UsersBlogApi {
+
+    private final UsersBlogService usersBlogService;
+
+    @PostMapping(value = "/validation/blog-name", consumes = APPLICATION_JSON_VALUE)
+    public Map<String, String> validateBlogName(@RequestBody Map<String, String> requestData) {
+        String blogName = requestData.get("blogName");
+
+        boolean isDuplicated = usersBlogService.duplicateBlogName(blogName);
+
+        Map<String, String> map = new HashMap<>();
+        map.put("isDuplicated", Boolean.toString(isDuplicated));
+        return map;
+    }
+
+    @PostMapping(value = "/validation/blog-url", consumes = APPLICATION_JSON_VALUE)
+    public Map<String, String> validateBlogUrl(@RequestBody Map<String, String> requestData) {
+        String blogUrl = requestData.get("blogUrl");
+
+        boolean isDuplicated = usersBlogService.duplicateBlogUrl(blogUrl);
+
+        Map<String, String> map = new HashMap<>();
+        map.put("isDuplicated", Boolean.toString(isDuplicated));
+        return map;
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/blog/repository/UsersBlogRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/blog/repository/UsersBlogRepository.java
@@ -3,4 +3,8 @@ package kr.co.finote.backend.src.blog.repository;
 import kr.co.finote.backend.src.blog.domain.UsersBlog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UsersBlogRepository extends JpaRepository<UsersBlog, Integer> {}
+public interface UsersBlogRepository extends JpaRepository<UsersBlog, Integer> {
+    boolean existsByUrl(String url);
+
+    boolean existsByName(String name);
+}

--- a/src/main/java/kr/co/finote/backend/src/blog/service/UsersBlogService.java
+++ b/src/main/java/kr/co/finote/backend/src/blog/service/UsersBlogService.java
@@ -1,0 +1,20 @@
+package kr.co.finote.backend.src.blog.service;
+
+import kr.co.finote.backend.src.blog.repository.UsersBlogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UsersBlogService {
+
+    private final UsersBlogRepository usersBlogRepository;
+
+    public boolean duplicateBlogName(String blogName) {
+        return usersBlogRepository.existsByName(blogName);
+    }
+
+    public boolean duplicateBlogUrl(String url) {
+        return usersBlogRepository.existsByUrl(url);
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/user/api/LoginApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/LoginApi.java
@@ -2,17 +2,14 @@ package kr.co.finote.backend.src.user.api;
 
 import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
-import kr.co.finote.backend.global.authentication.oauth.google.GoogleAccessTokenDto;
-import kr.co.finote.backend.global.authentication.oauth.google.GoogleLoginResponseDto;
 import kr.co.finote.backend.global.authentication.oauth.google.GoogleOauth;
-import kr.co.finote.backend.global.authentication.oauth.google.GoogleOauthUserInfoDto;
+import kr.co.finote.backend.global.authentication.oauth.google.dto.request.GoogleAccessTokenRequest;
+import kr.co.finote.backend.global.authentication.oauth.google.dto.response.GoogleLoginResponse;
+import kr.co.finote.backend.global.authentication.oauth.google.dto.response.GoogleOauthUserInfoResponse;
 import kr.co.finote.backend.src.user.service.LoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,18 +33,17 @@ public class LoginApi {
     }
 
     @GetMapping("/auth/google/")
-    public GoogleLoginResponseDto auth(@RequestParam String code) {
+    public GoogleLoginResponse auth(@RequestParam String code) {
         log.info("Code from Google social Login API {}", code);
 
-        GoogleAccessTokenDto googleAccessToken = loginService.getGoogleAccessToken(code);
-        GoogleOauthUserInfoDto GoogleOauthUserInfo = loginService.getGoogleUserInfo(googleAccessToken);
+        GoogleAccessTokenRequest googleAccessToken = loginService.getGoogleAccessToken(code);
+        GoogleOauthUserInfoResponse GoogleOauthUserInfo =
+                loginService.getGoogleUserInfo(googleAccessToken);
 
-        // TODO : userinfo를 가지고 repository 접근해서 최초 로그인과 이미 존재하는 회원 구분
         Boolean newUser = loginService.saveUser(GoogleOauthUserInfo);
 
-        // TODO : ResponseDTO 반환
-        GoogleLoginResponseDto response =
-                GoogleLoginResponseDto.builder()
+        GoogleLoginResponse response =
+                GoogleLoginResponse.builder()
                         .accessToken(googleAccessToken.getAccessToken())
                         .refreshToken(googleAccessToken.getRefreshToken())
                         .newUser(newUser)

--- a/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
@@ -21,13 +21,13 @@ public class UserApi {
     private final UserService userService;
 
     @PostMapping(value = "/validation/nickname", consumes = APPLICATION_JSON_VALUE)
-    public Map<String, String> validateNickname(@RequestBody Map<String, String> requestData) {
+    public Map<String, Boolean> validateNickname(@RequestBody Map<String, String> requestData) {
         String nickname = requestData.get("nickname");
 
         boolean isDuplicated = userService.duplicateNickname(nickname);
 
-        Map<String, String> map = new HashMap<>();
-        map.put("isDuplicated", Boolean.toString(isDuplicated));
+        Map<String, Boolean> map = new HashMap<>();
+        map.put("isDuplicated", isDuplicated);
         return map;
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
@@ -1,0 +1,33 @@
+package kr.co.finote.backend.src.user.api;
+
+import static org.springframework.http.MediaType.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import kr.co.finote.backend.src.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserApi {
+
+    private final UserService userService;
+
+    @PostMapping(value = "/validation/nickname", consumes = APPLICATION_JSON_VALUE)
+    public Map<String, String> validateNickname(@RequestBody Map<String, String> requestData) {
+        String nickname = requestData.get("nickname");
+
+        boolean isDuplicated = userService.duplicateNickname(nickname);
+
+        Map<String, String> map = new HashMap<>();
+        map.put("isDuplicated", Boolean.toString(isDuplicated));
+        return map;
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/user/repository/UserRepository.java
@@ -4,7 +4,9 @@ import kr.co.finote.backend.src.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
-    public User findByUsername(String username);
+    User findByUsername(String username);
 
-    public User findByEmail(String email);
+    User findByEmail(String email);
+
+    boolean existsByNickName(String nickName);
 }

--- a/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
@@ -1,0 +1,18 @@
+package kr.co.finote.backend.src.user.service;
+
+import kr.co.finote.backend.src.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public boolean duplicateNickname(String nickname) {
+        return userRepository.existsByNickName(nickname);
+    }
+}


### PR DESCRIPTION
### ✍🏻 개요
닉네임, 블로그이름, 블로그 URL을 중복 검사하는 API 

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

<br>

### ❓ 변경 사항
- 해당 API 작성
- 블로그이름, 블로그 URL API는 /blogs 로 시작하도록 변경

<br>

### 👥 To Reviewers
- 기능과 별개로 기존 Dto 팀 컨벤션 지키지 않던 클래스 네이밍 및 패키지 구조 수정하였습니다.
