### PR TITLE
[FIN-128] fix: 비로그인 유저 글 작성에 따른 작성자 정보 설정

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
+++ b/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
@@ -1,6 +1,7 @@
 package kr.co.finote.backend.src.article.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,10 +41,10 @@ public class ArticleApi {
                 .id(article.getId())
                 .title(article.getTitle())
                 .body(article.getTitle())
-                .authorId(article.getUser().getId())
-                .authorNickname(article.getUser().getNickname())
-                .profileImageUrl(article.getUser().getProfileImageUrl())
-                .createDate(article.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .authorId("author")
+                .authorNickname("nickname")
+                .profileImageUrl("")
+                .createDate(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
                 .build();
     }
 }


### PR DESCRIPTION
### ✍🏻 개요
비로그인 유저 글 작성을 위한 작성자 정보 설정

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 인프랩 데모를 위해 비로그인 유저도 글 작성 가능하도록 수정
- 작성자 정보를 가져오는데 에러 발생
- 임시로 작성자 정보 하드코딩

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
