### PR TITLE
[FIN-161] feat: 유저 로그인 상태 확인 API

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,20 +1,21 @@
 REPOSITORY=/home/ubuntu/finote/finote-backend
+# shellcheck disable=SC2164
 cd $REPOSITORY
 
-APP_NAME=finote
+# shellcheck disable=SC2010
 JAR_NAME=$(ls $REPOSITORY/build/libs/ | grep 'SNAPSHOT.jar' | tail -n 1)
 JAR_PATH=$REPOSITORY/build/libs/$JAR_NAME
 
-CURRENT_PID=$(pgrep -f $APP_NAME)
+CURRENT_PID=$(lsof -t -i :8080)
 
-if [ -z $CURRENT_PID ]
+if [ -z "$CURRENT_PID" ]
 then
   echo "> 종료할 애플리케이션이 없습니다."
 else
   echo "> kill -9 $CURRENT_PID"
-  kill -15 $CURRENT_PID
+  kill -15 "$CURRENT_PID"
   sleep 5
 fi
 
 echo "> Deploy - $JAR_PATH "
-nohup java -jar $JAR_PATH > /dev/null 2> /dev/null < /dev/null &
+nohup java -jar "$JAR_PATH" > /dev/null 2> /dev/null < /dev/null &

--- a/src/main/java/kr/co/finote/backend/BackendApplication.java
+++ b/src/main/java/kr/co/finote/backend/BackendApplication.java
@@ -1,14 +1,18 @@
 package kr.co.finote.backend;
 
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@Slf4j
 public class BackendApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(BackendApplication.class, args);
+        log.info("Server Start Time : {}", LocalDateTime.now());
     }
 }

--- a/src/main/java/kr/co/finote/backend/global/config/WebConfig.java
+++ b/src/main/java/kr/co/finote/backend/global/config/WebConfig.java
@@ -12,7 +12,11 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry
                 .addInterceptor(new SessionInterceptor())
-                .addPathPatterns("/users/**", "/articles/**") // TODO https 설정 후 글쓰기 권한 확인 필요
-                .excludePathPatterns("/users/auth/google", "/users/validation/**", "/articles/{articleId}");
+                .addPathPatterns("/users/**", "/articles/**")
+                .excludePathPatterns(
+                        "/users/auth/google",
+                        "/users/validation/**",
+                        "/users/check-login-status",
+                        "/articles/{articleId}");
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/HealthCheckController.java
+++ b/src/main/java/kr/co/finote/backend/src/HealthCheckController.java
@@ -1,5 +1,6 @@
 package kr.co.finote.backend.src;
 
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/")
 public class HealthCheckController {
 
+    @Operation(summary = "서버 상태 체크")
     @GetMapping("/health-check")
     public boolean getHealthCheck() {
         return true;

--- a/src/main/java/kr/co/finote/backend/src/user/api/LoginApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/LoginApi.java
@@ -39,4 +39,10 @@ public class LoginApi {
 
         return GoogleLoginResponse.createGoogleLoginResponse(saveUserResponse.getIsNewUser());
     }
+
+    @Operation(summary = "유저 로그인 상태 확인")
+    @GetMapping("/check-login-status")
+    public boolean checkLoginStatus(HttpServletRequest servletRequest) {
+        return sessionService.checkLoginStatus(servletRequest);
+    }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/service/SessionService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/SessionService.java
@@ -15,4 +15,9 @@ public class SessionService {
         HttpSession session = servletRequest.getSession();
         session.setAttribute(SessionUtils.LOGIN_USER, loginUser);
     }
+
+    public boolean checkLoginStatus(HttpServletRequest servletRequest) {
+        HttpSession session = servletRequest.getSession(false);
+        return session != null && session.getAttribute(SessionUtils.LOGIN_USER) != null;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,7 +55,7 @@ springdoc:
     path: /finote-api-docs
     disable-swagger-default-url: true
     tags-sorter: alpha
-    operations-sorter: alpha
+    operations-sorter: method, alpha
   api-docs:
     path: /api-docs
 


### PR DESCRIPTION
### ✍🏻 개요
JSESSIONID httpOnly로 프론트엔드에서 불러와서 사용 불가함에 따라 프론트 로그인 상태 유지를 위해 로그인 상태를 확인할 수 있는 API 구현

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 유저 로그인 상태를 확인할 수 있는 API 구현
- CD 구현 시 배포 쉘 스크립트 수정
- swagger method 정렬 순서 method 적용

<br>

### 👥 To Reviewers
