### PR TITLE
[FIN-167] feat: 서버 에러 로그 slack 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ out/
 .vscode/
 
 application-*.properties
+application.properties
 
 .DS_Store
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'com.github.maricn:logback-slack-appender:1.6.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/finote/backend/global/advice/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/finote/backend/global/advice/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
             MethodArgumentNotValidException e) {
-        log.error(e.getMessage());
+        log.error("[{}]", e.getMessage());
 
         ErrorResponse errorResponse = ErrorResponse.hasDetailError(ResponseCode.INVALID_INPUT_VALUE, e);
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
@@ -26,16 +26,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-        log.error(e.getMessage());
-
+        int value = e.getResponseCode().getStatus().value();
+        String message = e.getResponseCode().getMessage();
+        log.error("[{} : {}]", value, message);
         ErrorResponse errorResponse = ErrorResponse.noDetailError(e.getResponseCode());
         return new ResponseEntity<>(errorResponse, e.getResponseCode().getStatus());
     }
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("[{}]", e.getMessage());
 
-        log.error(e.getMessage());
         ErrorResponse errorResponse = ErrorResponse.noDetailError(ResponseCode.INTERNAL_ERROR);
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
+++ b/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
@@ -18,6 +18,7 @@ public enum ResponseCode {
     INVALID_INPUT_VALUE(BAD_REQUEST, "400_INVALID_INPUT_VALUE", "입력값이 올바르지 않습니다."),
 
     /** Users error */
+    USER_NOT_FOUND(NOT_FOUND, "404_USER_NOT_FOUND", "존재하지 않는 유저입니다."),
     DUPLICATE_NICKNAME(BAD_REQUEST, "400_DUPLICATE_NICKNAME", "중복된 닉네임입니다."),
     NICKNAME_TOO_LONG(BAD_REQUEST, "400_NICKNAME_TOO_LONG", "닉네임은 100자 이하로 입력해주세요."),
     DUPLICATE_BLOG_NAME(BAD_REQUEST, "400_DUPLICATE_BLOG_NAME", "중복된 블로그명입니다."),

--- a/src/main/java/kr/co/finote/backend/src/HealthCheckController.java
+++ b/src/main/java/kr/co/finote/backend/src/HealthCheckController.java
@@ -11,7 +11,5 @@ public class HealthCheckController {
 
     @Operation(summary = "Server Health Check")
     @GetMapping("/health-check")
-    public boolean getHealthCheck() {
-        return true;
-    }
+    public void getHealthCheck() {}
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -6,6 +6,7 @@ import kr.co.finote.backend.src.article.domain.Article;
 import kr.co.finote.backend.src.article.dto.request.ArticleRequest;
 import kr.co.finote.backend.src.article.repository.ArticleRepository;
 import kr.co.finote.backend.src.user.domain.User;
+import kr.co.finote.backend.src.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,9 +15,14 @@ import org.springframework.stereotype.Service;
 public class ArticleService {
 
     private final ArticleRepository articleRepository;
+    private final UserRepository userRepository;
 
     public Long save(ArticleRequest articleRequest, User loginUser) {
-        Article article = Article.createArticle(articleRequest, loginUser);
+        User user =
+                userRepository
+                        .findByEmailAndIsDeleted("hyunyelim25@gmail.com", false)
+                        .orElseThrow(() -> new NotFoundException(ResponseCode.USER_NOT_FOUND));
+        Article article = Article.createArticle(articleRequest, user); // TODO 로그인 후 login user로 변경
         return articleRepository.save(article).getId();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,3 +67,9 @@ chatgpt:
   model: ${GPT_MODEL}
   max-token: ${GPT_MAX_TOKEN}
   temperature: ${GPT_TEMPERATURE}
+
+logging:
+  slack:
+    webhook-uri: ${SLACK_WEBHOOK_URI}
+  config: classpath:logback-slack.xml
+

--- a/src/main/resources/logback-slack.xml
+++ b/src/main/resources/logback-slack.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <property resource="application.properties" />
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-uri"/>
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <channel>${SLACK_CHANNEL}</channel>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level - %msg%n</pattern>
+        </layout>
+        <username>${SLACK_USERNAME}</username>
+        <iconEmoji>:face_with_spiral_eyes:</iconEmoji>
+        <colorCoding>true</colorCoding>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+    <root>
+        <level value="INFO"/>
+        <appender-ref ref="ASYNC_SLACK"/>
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
### ✍🏻 개요
프론트와 백엔드 개발자 모두 편하게 서버 에러로그를 볼 수 있도록 슬랙 채널 연동

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 서버 에러 로그를 slack에서 모두 확인할 수 있도록 logback와 slack 연동

<br>

### 👥 To Reviewers
- 설정 파일 관련해서는 슬랙에 공유 드리겠습니다!
