### PR TITLE
[FIN-176] 로그아웃 API 구현

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
+++ b/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
@@ -32,7 +32,8 @@ public enum ResponseCode {
     /** authentication/authorization error */
     UNAUTHENTICATED(UNAUTHORIZED, "401_UNAUTHORIZED", "인증되지 않은 사용자입니다."),
     INVALID_ACCESS_TOKEN(UNAUTHORIZED, "401_INVALID_ACCESS_TOKEN", "액세스 토큰이 유효하지 않습니다."),
-    NO_REFRESH_TOKEN(UNAUTHORIZED, "401_NO_REFRESH_TOKEN", "저장된 리프레시 토큰이 없습니다.");
+    NO_REFRESH_TOKEN(UNAUTHORIZED, "401_NO_REFRESH_TOKEN", "저장된 리프레시 토큰이 없습니다."),
+    EXPIRED_REFRESH_TOKEN(UNAUTHORIZED, "401_EXPIRE_REFRESH_TOKEN", "만료된 리프레시 토큰입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
+++ b/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
                 .authorizeRequests()
                 .antMatchers("users/**")
                 .permitAll()
-                .antMatchers("/users/nickname", "/users/blog-info", "/users/additional-info")
+                .antMatchers("/users/nickname", "/users/blog-info", "/users/additional-info", "users/logout")
                 .authenticated()
                 .antMatchers("/articles/**")
                 .permitAll()

--- a/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
+++ b/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                 .antMatchers("users/**")
                 .permitAll()
                 .antMatchers(
-                        "/users/nickname", "/users/blog-info", "/users/additional-info", "users/logout")
+                        "/users/nickname", "/users/blog-info", "/users/additional-info", "/users/logout")
                 .authenticated()
                 .antMatchers("/articles/**")
                 .permitAll()

--- a/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
+++ b/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig {
                 .authorizeRequests()
                 .antMatchers("users/**")
                 .permitAll()
-                .antMatchers("/users/nickname", "/users/blog-info", "/users/additional-info", "users/logout")
+                .antMatchers(
+                        "/users/nickname", "/users/blog-info", "/users/additional-info", "users/logout")
                 .authenticated()
                 .antMatchers("/articles/**")
                 .permitAll()

--- a/src/main/java/kr/co/finote/backend/global/jwt/JwtToken.java
+++ b/src/main/java/kr/co/finote/backend/global/jwt/JwtToken.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class JwtTokenDto {
+public class JwtToken {
 
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/kr/co/finote/backend/src/user/api/JwtApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/JwtApi.java
@@ -1,6 +1,7 @@
 package kr.co.finote.backend.src.user.api;
 
-import kr.co.finote.backend.global.jwt.JwtTokenDto;
+import io.swagger.v3.oas.annotations.Operation;
+import kr.co.finote.backend.global.jwt.JwtToken;
 import kr.co.finote.backend.src.user.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,8 +16,9 @@ public class JwtApi {
 
     private final JwtService jwtService;
 
+    @Operation(summary = "토큰 재발급", description = "해당 요청에서는 액세스 토큰, 리프레시 토큰이 언제나 재발급 처리")
     @PostMapping("/jwt/re-issue")
-    public JwtTokenDto reIssue(@RequestBody JwtTokenDto tokenDto) {
-        return jwtService.reIssue(tokenDto);
+    public JwtToken reIssue(@RequestBody JwtToken jwtToken) {
+        return jwtService.reIssue(jwtToken);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/api/LoginApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/LoginApi.java
@@ -5,14 +5,12 @@ import javax.servlet.http.HttpServletRequest;
 import kr.co.finote.backend.global.authentication.oauth.google.dto.request.GoogleAccessToken;
 import kr.co.finote.backend.global.authentication.oauth.google.dto.response.GoogleLoginResponse;
 import kr.co.finote.backend.global.authentication.oauth.google.dto.response.GoogleUserInfo;
+import kr.co.finote.backend.global.jwt.JwtToken;
 import kr.co.finote.backend.src.user.dto.response.GoogleLoginCodeResponse;
 import kr.co.finote.backend.src.user.service.LoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -42,4 +40,11 @@ public class LoginApi {
         log.info("code : {}", code);
         return GoogleLoginCodeResponse.createGoogleLoginCodeResponse(code);
     }
+
+    @Operation(summary = "로그아웃", description = "토큰 만료기간과 상관 없이 액세스, 리프레시 토큰 모두 초기화")
+    @PostMapping("/logout")
+    public void logout(@RequestBody JwtToken jwtToken) {
+        loginService.logout(jwtToken);
+    }
+
 }

--- a/src/main/java/kr/co/finote/backend/src/user/api/LoginApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/LoginApi.java
@@ -46,5 +46,4 @@ public class LoginApi {
     public void logout(@RequestBody JwtToken jwtToken) {
         loginService.logout(jwtToken);
     }
-
 }

--- a/src/main/java/kr/co/finote/backend/src/user/service/JwtService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/JwtService.java
@@ -2,7 +2,7 @@ package kr.co.finote.backend.src.user.service;
 
 import kr.co.finote.backend.global.code.ResponseCode;
 import kr.co.finote.backend.global.exception.CustomException;
-import kr.co.finote.backend.global.jwt.JwtTokenDto;
+import kr.co.finote.backend.global.jwt.JwtToken;
 import kr.co.finote.backend.global.jwt.JwtTokenProvider;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.repository.UserRepository;
@@ -18,8 +18,8 @@ public class JwtService {
     private final UserRepository userRepository;
 
     @Transactional
-    public JwtTokenDto reIssue(JwtTokenDto request) {
-        String refreshToken = request.getRefreshToken();
+    public JwtToken reIssue(JwtToken jwtToken) {
+        String refreshToken = jwtToken.getRefreshToken();
 
         User user =
                 userRepository
@@ -28,13 +28,14 @@ public class JwtService {
 
         if (jwtTokenProvider.validateTokenExpiration(refreshToken)) {
             String token = jwtTokenProvider.createToken(user.getEmail());
-            return new JwtTokenDto(token, refreshToken);
+            String newRefreshToken = jwtTokenProvider.createRefreshToken();
+
+            user.updateRefreshToken(newRefreshToken);
+
+            return new JwtToken(token, newRefreshToken);
         }
 
-        String newRefreshToken = jwtTokenProvider.createRefreshToken();
-        user.updateRefreshToken(newRefreshToken);
-        String token = jwtTokenProvider.createToken(user.getEmail());
-
-        return new JwtTokenDto(token, newRefreshToken);
+        user.updateRefreshToken(null);
+        throw new CustomException(ResponseCode.EXPIRED_REFRESH_TOKEN);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/service/LoginService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/LoginService.java
@@ -8,6 +8,9 @@ import kr.co.finote.backend.global.authentication.oauth.google.GoogleOauth;
 import kr.co.finote.backend.global.authentication.oauth.google.dto.request.GoogleAccessToken;
 import kr.co.finote.backend.global.authentication.oauth.google.dto.response.GoogleLoginResponse;
 import kr.co.finote.backend.global.authentication.oauth.google.dto.response.GoogleUserInfo;
+import kr.co.finote.backend.global.code.ResponseCode;
+import kr.co.finote.backend.global.exception.CustomException;
+import kr.co.finote.backend.global.jwt.JwtToken;
 import kr.co.finote.backend.global.jwt.JwtTokenProvider;
 import kr.co.finote.backend.global.utils.StringUtils;
 import kr.co.finote.backend.src.user.domain.User;
@@ -85,5 +88,17 @@ public class LoginService {
 
             return GoogleLoginResponse.freshUser(user, jwtTokenProvider);
         }
+    }
+
+    @Transactional
+    public void logout(JwtToken jwtToken) {
+        String refreshToken = jwtToken.getRefreshToken();
+
+        User user =
+                userRepository
+                        .findByRefreshTokenAndIsDeleted(refreshToken, false)
+                        .orElseThrow(() -> new CustomException(ResponseCode.NO_REFRESH_TOKEN));
+
+        user.updateRefreshToken(null);
     }
 }


### PR DESCRIPTION
### ✍🏻 개요
FIN-176 티켓에 대한 구현 내용입니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 리팩토링

<br>

### ❓ 변경 사항
- 로그아웃 시 Refresh Token 삭제
- Active한 User에 대해서는 액세스 토큰, 리프레시 토큰을 함께 발급하도록 변경

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
