### PR TITLE
[FIN-176] 로그아웃 API 구현

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
+++ b/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import kr.co.finote.backend.global.authentication.CustomAuthenticationEntryPoint;
 import kr.co.finote.backend.global.jwt.JwtAuthenticationFilter;
 import kr.co.finote.backend.global.jwt.JwtTokenProvider;
+import kr.co.finote.backend.src.user.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -28,6 +29,7 @@ public class SecurityConfig {
     private String[] corsUrls;
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtService jwtService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -58,7 +60,7 @@ public class SecurityConfig {
                 .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
                 .and()
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        new JwtAuthenticationFilter(jwtTokenProvider, jwtService),
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
+++ b/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
@@ -44,13 +44,9 @@ public class SecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("users/**")
-                .permitAll()
                 .antMatchers(
                         "/users/nickname", "/users/blog-info", "/users/additional-info", "/users/logout")
                 .authenticated()
-                .antMatchers("/articles/**")
-                .permitAll()
                 .antMatchers("/articles/ai-search")
                 .authenticated()
                 .antMatchers(HttpMethod.POST, "/articles")

--- a/src/main/java/kr/co/finote/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/co/finote/backend/global/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package kr.co.finote.backend.global.jwt;
 import java.io.IOException;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
+import kr.co.finote.backend.src.user.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -12,13 +13,16 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public class JwtAuthenticationFilter extends GenericFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtService jwtService;
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
         String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
 
-        if (token != null && jwtTokenProvider.validateTokenExpiration(token)) {
+        if (token != null
+                && jwtTokenProvider.validateTokenExpiration(token)
+                && jwtService.hasRefreshToken(token)) {
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/kr/co/finote/backend/src/user/service/LoginService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/LoginService.java
@@ -9,7 +9,7 @@ import kr.co.finote.backend.global.authentication.oauth.google.dto.request.Googl
 import kr.co.finote.backend.global.authentication.oauth.google.dto.response.GoogleLoginResponse;
 import kr.co.finote.backend.global.authentication.oauth.google.dto.response.GoogleUserInfo;
 import kr.co.finote.backend.global.code.ResponseCode;
-import kr.co.finote.backend.global.exception.CustomException;
+import kr.co.finote.backend.global.exception.UnAuthorizedException;
 import kr.co.finote.backend.global.jwt.JwtToken;
 import kr.co.finote.backend.global.jwt.JwtTokenProvider;
 import kr.co.finote.backend.global.utils.StringUtils;
@@ -97,7 +97,7 @@ public class LoginService {
         User user =
                 userRepository
                         .findByRefreshTokenAndIsDeleted(refreshToken, false)
-                        .orElseThrow(() -> new CustomException(ResponseCode.NO_REFRESH_TOKEN));
+                        .orElseThrow(() -> new UnAuthorizedException(ResponseCode.NO_REFRESH_TOKEN));
 
         user.updateRefreshToken(null);
     }


### PR DESCRIPTION
### ✍🏻 개요
로그아웃 관련 예외 처리를 추가하였습니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
이제 Access Token이 유효해도, Refresh Token이 서버에 저장된 것과 일치하는 지 확인하고 나야 인증이 성공합니다.

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
