### PR TITLE
[FIN-226] feat: 팔로잉/팔로워 목록 API

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/api/AiSearchApi.java
+++ b/src/main/java/kr/co/finote/backend/src/article/api/AiSearchApi.java
@@ -5,7 +5,9 @@ import javax.validation.Valid;
 import kr.co.finote.backend.src.article.dto.request.AiSearchRequest;
 import kr.co.finote.backend.src.article.dto.response.AiSearchResponse;
 import kr.co.finote.backend.src.article.service.AiSearchService;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,9 +15,10 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/articles")
 @RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class AiSearchApi {
 
-    private final AiSearchService aiSearchService;
+    AiSearchService aiSearchService;
 
     @Operation(summary = "AI 검색")
     @PostMapping("/ai-search")

--- a/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
+++ b/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
@@ -14,15 +14,18 @@ import kr.co.finote.backend.src.article.dto.response.PostArticleResponse;
 import kr.co.finote.backend.src.article.dto.response.RelatedArticleResponse;
 import kr.co.finote.backend.src.article.service.ArticleService;
 import kr.co.finote.backend.src.user.domain.User;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/articles")
 @RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class ArticleApi {
 
-    private final ArticleService articleService;
+    ArticleService articleService;
 
     @Operation(summary = "블로그 글 작성")
     @PostMapping

--- a/src/main/java/kr/co/finote/backend/src/common/api/CommonApi.java
+++ b/src/main/java/kr/co/finote/backend/src/common/api/CommonApi.java
@@ -4,7 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import kr.co.finote.backend.global.annotation.Login;
 import kr.co.finote.backend.src.article.dto.response.ArticlePreviewListResponse;
 import kr.co.finote.backend.src.article.service.ArticleService;
-import kr.co.finote.backend.src.common.dto.FollowResultResponse;
+import kr.co.finote.backend.src.common.dto.response.FollowResultResponse;
+import kr.co.finote.backend.src.common.dto.response.FollowUserListResponse;
 import kr.co.finote.backend.src.common.service.FollowService;
 import kr.co.finote.backend.src.user.domain.User;
 import lombok.AccessLevel;
@@ -40,5 +41,17 @@ public class CommonApi {
     public ArticlePreviewListResponse trendArticles(
             @RequestParam int page, @RequestParam(required = false, defaultValue = "30") int size) {
         return articleService.trendArticles(page, size);
+    }
+
+    @Operation(summary = "유저 팔로잉 목록", description = "닉네임에 해당하는 유저의 팔로잉 목록 조회")
+    @GetMapping("/followings/{nickname}")
+    public FollowUserListResponse followings(@PathVariable String nickname) {
+        return followService.followings(nickname);
+    }
+
+    @Operation(summary = "유저 팔로워 목록", description = "닉네임에 해당하는 유저의 팔로워 목록 조회")
+    @GetMapping("/followers/{nickname}")
+    public FollowUserListResponse followers(@PathVariable String nickname) {
+        return followService.followers(nickname);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/common/dto/response/FollowResultResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/common/dto/response/FollowResultResponse.java
@@ -1,4 +1,4 @@
-package kr.co.finote.backend.src.common.dto;
+package kr.co.finote.backend.src.common.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/kr/co/finote/backend/src/common/dto/response/FollowUserListResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/common/dto/response/FollowUserListResponse.java
@@ -1,0 +1,21 @@
+package kr.co.finote.backend.src.common.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class FollowUserListResponse {
+
+    List<FollowUserResponse> lists;
+
+    public static FollowUserListResponse of(List<FollowUserResponse> lists) {
+        return FollowUserListResponse.builder().lists(lists).build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/common/dto/response/FollowUserResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/common/dto/response/FollowUserResponse.java
@@ -1,0 +1,27 @@
+package kr.co.finote.backend.src.common.dto.response;
+
+import kr.co.finote.backend.src.user.domain.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class FollowUserResponse {
+
+    String nickName;
+    String profileImageUrl;
+    String blogName;
+
+    public static FollowUserResponse of(User user) {
+        return FollowUserResponse.builder()
+                .nickName(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .blogName(user.getBlogName())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/common/repository/FollowInfoRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/common/repository/FollowInfoRepository.java
@@ -1,12 +1,21 @@
 package kr.co.finote.backend.src.common.repository;
 
+import java.util.List;
 import java.util.Optional;
 import kr.co.finote.backend.src.common.domain.FollowInfo;
 import kr.co.finote.backend.src.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FollowInfoRepository extends JpaRepository<FollowInfo, Long> {
     Optional<FollowInfo> findByFromUserAndToUser(User fromUser, User toUser);
+
+    @Query("select fi from FollowInfo fi join fetch fi.toUser WHERE fi.fromUser = :fromUser")
+    List<FollowInfo> findAllWithFromUser(@Param("fromUser") User fromUser);
+
+    @Query("select fi from FollowInfo fi join fetch fi.fromUser WHERE fi.toUser = :toUser")
+    List<FollowInfo> findAllWithToUser(@Param("toUser") User toUser);
 }

--- a/src/main/java/kr/co/finote/backend/src/common/repository/FollowInfoRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/common/repository/FollowInfoRepository.java
@@ -13,9 +13,11 @@ import org.springframework.stereotype.Repository;
 public interface FollowInfoRepository extends JpaRepository<FollowInfo, Long> {
     Optional<FollowInfo> findByFromUserAndToUser(User fromUser, User toUser);
 
-    @Query("select fi from FollowInfo fi join fetch fi.toUser WHERE fi.fromUser = :fromUser")
+    @Query(
+            "select fi from FollowInfo fi join fetch fi.toUser WHERE fi.fromUser = :fromUser AND fi.isDeleted = false ")
     List<FollowInfo> findAllWithFromUser(@Param("fromUser") User fromUser);
 
-    @Query("select fi from FollowInfo fi join fetch fi.fromUser WHERE fi.toUser = :toUser")
+    @Query(
+            "select fi from FollowInfo fi join fetch fi.fromUser WHERE fi.toUser = :toUser AND fi.isDeleted = false")
     List<FollowInfo> findAllWithToUser(@Param("toUser") User toUser);
 }

--- a/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
+++ b/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
@@ -61,6 +61,8 @@ public class FollowService {
 
         if (result.isPresent()) {
             FollowInfo followInfo = result.get();
+            if (followInfo.getIsDeleted()) throw new InvalidInputException(ResponseCode.NOT_FOLLOWING);
+
             followInfo.updateIsDeleted(true);
             return FollowResultResponse.of(true);
         }

--- a/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
+++ b/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
@@ -1,11 +1,15 @@
 package kr.co.finote.backend.src.common.service;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.transaction.Transactional;
 import kr.co.finote.backend.global.code.ResponseCode;
 import kr.co.finote.backend.global.exception.InvalidInputException;
 import kr.co.finote.backend.src.common.domain.FollowInfo;
-import kr.co.finote.backend.src.common.dto.FollowResultResponse;
+import kr.co.finote.backend.src.common.dto.response.FollowResultResponse;
+import kr.co.finote.backend.src.common.dto.response.FollowUserListResponse;
+import kr.co.finote.backend.src.common.dto.response.FollowUserResponse;
 import kr.co.finote.backend.src.common.repository.FollowInfoRepository;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.service.UserService;
@@ -57,5 +61,29 @@ public class FollowService {
         }
 
         throw new InvalidInputException(ResponseCode.NOT_FOLLOWING);
+    }
+
+    public FollowUserListResponse followings(String nickname) {
+        User fromUser = userService.findByNickname(nickname);
+
+        List<FollowInfo> followings = followInfoRepository.findAllWithFromUser(fromUser);
+        List<FollowUserResponse> followUserResponses = ToFollowerUserResponseList(followings);
+
+        return FollowUserListResponse.of(followUserResponses);
+    }
+
+    public FollowUserListResponse followers(String nickname) {
+        User toUser = userService.findByNickname(nickname);
+
+        List<FollowInfo> followers = followInfoRepository.findAllWithToUser(toUser);
+        List<FollowUserResponse> followUserResponses = ToFollowerUserResponseList(followers);
+
+        return FollowUserListResponse.of(followUserResponses);
+    }
+
+    private List<FollowUserResponse> ToFollowerUserResponseList(List<FollowInfo> followInfos) {
+        return followInfos.stream()
+                .map(followInfo -> FollowUserResponse.of(followInfo.getToUser()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
+++ b/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
@@ -37,7 +37,12 @@ public class FollowService {
         Optional<FollowInfo> result = followInfoRepository.findByFromUserAndToUser(fromUser, toUser);
 
         if (result.isPresent()) {
-            throw new InvalidInputException(ResponseCode.ALREADY_FOLLOWING);
+            FollowInfo followInfo = result.get();
+            if (!followInfo.getIsDeleted())
+                throw new InvalidInputException(ResponseCode.ALREADY_FOLLOWING);
+
+            followInfo.updateIsDeleted(false);
+            return FollowResultResponse.of(true);
         }
 
         followInfoRepository.save(FollowInfo.of(fromUser, toUser));

--- a/src/main/java/kr/co/finote/backend/src/user/api/JwtApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/JwtApi.java
@@ -3,7 +3,9 @@ package kr.co.finote.backend.src.user.api;
 import io.swagger.v3.oas.annotations.Operation;
 import kr.co.finote.backend.global.jwt.JwtToken;
 import kr.co.finote.backend.src.user.service.JwtService;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,9 +14,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class JwtApi {
 
-    private final JwtService jwtService;
+    JwtService jwtService;
 
     @Operation(summary = "토큰 재발급", description = "해당 요청에서는 액세스 토큰, 리프레시 토큰이 언제나 재발급 처리")
     @PostMapping("/jwt/re-issue")

--- a/src/main/java/kr/co/finote/backend/src/user/api/LoginApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/LoginApi.java
@@ -8,7 +8,9 @@ import kr.co.finote.backend.global.authentication.oauth.google.dto.response.Goog
 import kr.co.finote.backend.global.jwt.JwtToken;
 import kr.co.finote.backend.src.user.dto.response.GoogleLoginCodeResponse;
 import kr.co.finote.backend.src.user.service.LoginService;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,9 +18,10 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/users")
 @Slf4j
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class LoginApi {
 
-    private final LoginService loginService;
+    LoginService loginService;
 
     @Operation(summary = "구글 로그인 처리", description = "프론트에서 발급받은 Code를 전달해주어야 함.")
     @GetMapping("/auth/google")

--- a/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
@@ -9,7 +9,9 @@ import kr.co.finote.backend.src.user.dto.request.*;
 import kr.co.finote.backend.src.user.dto.response.BlogResponse;
 import kr.co.finote.backend.src.user.dto.response.NicknameResponse;
 import kr.co.finote.backend.src.user.service.UserService;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -19,9 +21,10 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/users")
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class UserApi {
 
-    private final UserService userService;
+    UserService userService;
 
     /* Field Validation API */
     @Operation(summary = "닉네임 중복 검사")


### PR DESCRIPTION
### ✍🏻 개요
FIN-226에 대한 구현입니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 팔로워 / 팔로잉 목록 조회 API 구현
- 도메인 별 api 패키지 모두 FieldDefaults 설정 적용

<br>

### 👥 To Reviewers
AiSearchApi와 ArticleApi 통합은 일단 하지 않았습니다.

