### PR TITLE
fix: 팔로잉 목록 조회 로직 수정

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
+++ b/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
@@ -74,7 +74,7 @@ public class FollowService {
         User fromUser = userService.findByNickname(nickname);
 
         List<FollowInfo> followings = followInfoRepository.findAllWithFromUser(fromUser);
-        List<FollowUserResponse> followUserResponses = ToFollowerUserResponseList(followings);
+        List<FollowUserResponse> followUserResponses = FollwingUserList(followings);
 
         return FollowUserListResponse.of(followUserResponses);
     }
@@ -83,12 +83,18 @@ public class FollowService {
         User toUser = userService.findByNickname(nickname);
 
         List<FollowInfo> followers = followInfoRepository.findAllWithToUser(toUser);
-        List<FollowUserResponse> followUserResponses = ToFollowerUserResponseList(followers);
+        List<FollowUserResponse> followUserResponses = FollowerUserList(followers);
 
         return FollowUserListResponse.of(followUserResponses);
     }
 
-    private List<FollowUserResponse> ToFollowerUserResponseList(List<FollowInfo> followInfos) {
+    private List<FollowUserResponse> FollowerUserList(List<FollowInfo> followInfos) {
+        return followInfos.stream()
+                .map(followInfo -> FollowUserResponse.of(followInfo.getFromUser()))
+                .collect(Collectors.toList());
+    }
+
+    private List<FollowUserResponse> FollwingUserList(List<FollowInfo> followInfos) {
         return followInfos.stream()
                 .map(followInfo -> FollowUserResponse.of(followInfo.getToUser()))
                 .collect(Collectors.toList());


### PR DESCRIPTION
### ✍🏻 개요
FIN-223 팔로잉/팔로워 목록 API 구현에 코드 오류가 있었습니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
기존에 팔로워/팔로잉 목록 리스트를 만들 때 메서드 하나만 사용하고 있었는데, 두 케이스 코드가 달라야 정상적으로 로직이 수행됩니다. ToFollowerUserResponseList가 두 개의 메서드로 분리되었습니다.
<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
