### PR TITLE
[FIN-279] feat: 글 삭제 시 연관된 다른 테이블 데이터 삭제 및 관리

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
+++ b/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
@@ -101,7 +101,6 @@ public class ArticleApi {
     @PostMapping("/like/{article-id}")
     public LikeResponse postLike(
             @Login User loginUser, @PathVariable(ARTICLE_ID_PATH_VARIABLE) Long articleId) {
-
         return articleService.postLike(loginUser, articleId);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/domain/ArticleKeyword.java
+++ b/src/main/java/kr/co/finote/backend/src/article/domain/ArticleKeyword.java
@@ -32,4 +32,8 @@ public class ArticleKeyword extends BaseEntity {
             Article article, Keyword keyword, Double score) {
         return ArticleKeyword.builder().article(article).keyword(keyword).score(score).build();
     }
+
+    public void deleteArticleKeyword() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/repository/ArticleLikeRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/article/repository/ArticleLikeRepository.java
@@ -10,4 +10,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> {
     Optional<ArticleLike> findByUserAndArticle(User user, Article article);
+
+    void deleteAllByArticle(Article article);
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleKeywordService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleKeywordService.java
@@ -8,6 +8,7 @@ import kr.co.finote.backend.src.article.dto.KeywordScore;
 import kr.co.finote.backend.src.article.repository.ArticleKeywordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -32,5 +33,14 @@ public class ArticleKeywordService {
                 articleKeywordRepository.findAllByArticleAndIsDeleted(article, false);
         if (articleKeywordList.size() > KEYWORD_MAX_COUNT) return articleKeywordList.subList(0, 3);
         else return articleKeywordList;
+    }
+
+    @Transactional
+    public void deleteArticleKeyword(Article article) {
+        List<ArticleKeyword> articleKeywordList =
+                articleKeywordRepository.findAllByArticleAndIsDeleted(article, false);
+        for (ArticleKeyword articleKeyword : articleKeywordList) {
+            articleKeyword.deleteArticleKeyword();
+        }
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -257,5 +257,10 @@ public class ArticleService {
         }
 
         article.deleteArticle();
+
+        // 좋아요 내역 완전 삭제
+        articleLikeRepository.deleteAllByArticle(article);
+        // 키워드 내역 soft delete
+        articleKeywordService.deleteArticleKeyword(article);
     }
 }


### PR DESCRIPTION
### ✍🏻 개요
특정 글을 삭제함에 따라 연관된 다른 데이터들도 함께 삭제합니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- article keyword 데이터 soft delete
- article like 데이터 hard delete

<br>

### 👥 To Reviewers
삭제 과정은 노션에 정리해두었습니다! [노션 링크](https://www.notion.so/soma-meteor/da65f0ad2499477c820655a9739e897a?pvs=4)
