### PR TITLE
[FIN-295] feat: 유저가 좋아요 한 글의 갯수 API

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/advice/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/finote/backend/global/advice/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package kr.co.finote.backend.global.advice;
 
+import java.util.Arrays;
 import kr.co.finote.backend.global.code.ResponseCode;
 import kr.co.finote.backend.global.exception.CustomException;
 import kr.co.finote.backend.global.response.ErrorResponse;
@@ -35,9 +36,10 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
-        log.error("[Exception - {}]", e.getMessage());
-        log.error("[Exception - {}]", e.toString());
-
+        log.error("[Exception Message - {}]", e.getMessage());
+        log.error("[Exception String - {}]", e.toString());
+        StackTraceElement[] stackTrace = e.getStackTrace();
+        log.error("[Exception StackTrace - {}]", Arrays.toString(stackTrace));
         ErrorResponse errorResponse = ErrorResponse.noDetailError(ResponseCode.INTERNAL_ERROR);
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/kr/co/finote/backend/src/article/repository/ArticleLikeRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/article/repository/ArticleLikeRepository.java
@@ -12,4 +12,6 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> 
     Optional<ArticleLike> findByUserAndArticle(User user, Article article);
 
     void deleteAllByArticle(Article article);
+
+    int countByUserAndIsDeleted(User user, boolean isDeleted);
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleLikeService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleLikeService.java
@@ -1,0 +1,34 @@
+package kr.co.finote.backend.src.article.service;
+
+import java.util.Optional;
+import kr.co.finote.backend.src.article.domain.Article;
+import kr.co.finote.backend.src.article.domain.ArticleLike;
+import kr.co.finote.backend.src.article.repository.ArticleLikeRepository;
+import kr.co.finote.backend.src.user.domain.User;
+import kr.co.finote.backend.src.user.dto.response.LikeCountResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleLikeService {
+
+    private final ArticleLikeRepository articleLikeRepository;
+
+    public Optional<ArticleLike> findByUser(User user, Article article) {
+        return articleLikeRepository.findByUserAndArticle(user, article);
+    }
+
+    public void save(User user, Article article) {
+        articleLikeRepository.save(ArticleLike.createArticleLike(user, article));
+    }
+
+    public void deleteAllByArticle(Article article) {
+        articleLikeRepository.deleteAllByArticle(article);
+    }
+
+    public LikeCountResponse getLikeCount(User loginUser) {
+        return LikeCountResponse.createLikeCountResponse(
+                articleLikeRepository.countByUserAndIsDeleted(loginUser, false));
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
@@ -4,9 +4,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import javax.validation.Valid;
 import kr.co.finote.backend.global.annotation.Login;
 import kr.co.finote.backend.global.authentication.PrincipalDetails;
+import kr.co.finote.backend.src.article.service.ArticleLikeService;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.dto.request.*;
 import kr.co.finote.backend.src.user.dto.response.BlogResponse;
+import kr.co.finote.backend.src.user.dto.response.LikeCountResponse;
 import kr.co.finote.backend.src.user.dto.response.NicknameResponse;
 import kr.co.finote.backend.src.user.service.UserService;
 import lombok.AccessLevel;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserApi {
 
     UserService userService;
+    ArticleLikeService articleLikeService;
 
     /* Field Validation API */
     @Operation(summary = "닉네임 중복 검사")
@@ -67,5 +70,11 @@ public class UserApi {
         PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
         User loginUser = principal.getUser();
         userService.editAdditionalInfo(loginUser, request);
+    }
+
+    @Operation(summary = "내가 좋아요 한 글의 갯수")
+    @GetMapping("/articles/like/count")
+    public LikeCountResponse getLikeCount(@Login User loginUser) {
+        return articleLikeService.getLikeCount(loginUser);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/dto/response/LikeCountResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/response/LikeCountResponse.java
@@ -1,0 +1,15 @@
+package kr.co.finote.backend.src.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikeCountResponse {
+
+    private int likeCount;
+
+    public static LikeCountResponse createLikeCountResponse(int likeCount) {
+        return new LikeCountResponse(likeCount);
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
@@ -4,7 +4,6 @@ import kr.co.finote.backend.global.code.ResponseCode;
 import kr.co.finote.backend.global.exception.InvalidInputException;
 import kr.co.finote.backend.global.exception.NotFoundException;
 import kr.co.finote.backend.global.exception.UnAuthorizedException;
-import kr.co.finote.backend.src.article.repository.ArticleRepository;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.dto.request.AdditionalInfoRequest;
 import kr.co.finote.backend.src.user.repository.UserRepository;
@@ -22,7 +21,6 @@ public class UserService {
     public static final int BLOG_NAME_MAX_LENGTH = 100;
     public static final int BLOG_URL_MAX_LENGTH = 100;
     private final UserRepository userRepository;
-    private final ArticleRepository articleRepository;
 
     public void validateNickname(String nickname) {
         boolean existsByNickname = userRepository.existsByNicknameAndIsDeleted(nickname, false);


### PR DESCRIPTION
### ✍🏻 개요
유저가 좋아요 한 블로그 글의 갯수를 받아오는 API

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- ArticleLikeService 분리
- 유저가 좋아요 한 글의 좋아요 갯수 API
- Exception log 추가

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
