### PR TITLE
[FIN-305] feat: 글 조회 시 팔로우 여부 필드 추가

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/annotation/LoginOptional.java
+++ b/src/main/java/kr/co/finote/backend/global/annotation/LoginOptional.java
@@ -7,4 +7,4 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Liked {}
+public @interface LoginOptional {}

--- a/src/main/java/kr/co/finote/backend/global/argumentresolver/LoginOptionalArgumentResolver.java
+++ b/src/main/java/kr/co/finote/backend/global/argumentresolver/LoginOptionalArgumentResolver.java
@@ -1,7 +1,7 @@
 package kr.co.finote.backend.global.argumentresolver;
 
 import javax.servlet.http.HttpServletRequest;
-import kr.co.finote.backend.global.annotation.Liked;
+import kr.co.finote.backend.global.annotation.LoginOptional;
 import kr.co.finote.backend.global.code.ResponseCode;
 import kr.co.finote.backend.global.exception.UnAuthorizedException;
 import kr.co.finote.backend.global.jwt.JwtTokenProvider;
@@ -19,17 +19,17 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class LikedArgumentResolver implements HandlerMethodArgumentResolver {
+public class LoginOptionalArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserService userService;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        boolean hasLikedAnnotation = parameter.hasParameterAnnotation(Liked.class);
-        boolean hasMemberType = User.class.isAssignableFrom(parameter.getParameterType());
+        boolean hasLoginOptionalAnnotation = parameter.hasParameterAnnotation(LoginOptional.class);
+        boolean hasUserType = User.class.isAssignableFrom(parameter.getParameterType());
 
-        return hasLikedAnnotation && hasMemberType;
+        return hasLoginOptionalAnnotation && hasUserType;
     }
 
     @Override

--- a/src/main/java/kr/co/finote/backend/global/argumentresolver/LoginUserArgumentResolver.java
+++ b/src/main/java/kr/co/finote/backend/global/argumentresolver/LoginUserArgumentResolver.java
@@ -16,9 +16,9 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
-        boolean hasMemberType = User.class.isAssignableFrom(parameter.getParameterType());
+        boolean hasUserType = User.class.isAssignableFrom(parameter.getParameterType());
 
-        return hasLoginAnnotation && hasMemberType;
+        return hasLoginAnnotation && hasUserType;
     }
 
     @Override

--- a/src/main/java/kr/co/finote/backend/global/config/WebConfig.java
+++ b/src/main/java/kr/co/finote/backend/global/config/WebConfig.java
@@ -1,7 +1,7 @@
 package kr.co.finote.backend.global.config;
 
 import java.util.List;
-import kr.co.finote.backend.global.argumentresolver.LikedArgumentResolver;
+import kr.co.finote.backend.global.argumentresolver.LoginOptionalArgumentResolver;
 import kr.co.finote.backend.global.argumentresolver.LoginUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -12,11 +12,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final LikedArgumentResolver likedArgumentResolver;
+    private final LoginOptionalArgumentResolver loginOptionalArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new LoginUserArgumentResolver());
-        resolvers.add(likedArgumentResolver);
+        resolvers.add(loginOptionalArgumentResolver);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
+++ b/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import javax.validation.Valid;
-import kr.co.finote.backend.global.annotation.Liked;
 import kr.co.finote.backend.global.annotation.Login;
+import kr.co.finote.backend.global.annotation.LoginOptional;
 import kr.co.finote.backend.src.article.domain.Article;
 import kr.co.finote.backend.src.article.dto.request.AiSearchRequest;
 import kr.co.finote.backend.src.article.dto.request.ArticleRequest;
@@ -41,15 +41,15 @@ public class ArticleApi {
 
     @Operation(summary = "블로그 id로 글 조회")
     @GetMapping("/{articleId}")
-    public ArticleResponse getArticle(@Liked User likedUser, @PathVariable Long articleId) {
-        return articleService.lookupById(likedUser, articleId);
+    public ArticleResponse getArticle(@LoginOptional User user, @PathVariable Long articleId) {
+        return articleService.lookupById(user, articleId);
     }
 
     @Operation(summary = "블로그 작성자 닉네임, 글 제목으로 조회")
     @GetMapping("/{nickname}/{title}")
     public ArticleResponse getArticleByNicknameAndTitle(
-            @Liked User likedUser, @PathVariable String nickname, @PathVariable String title) {
-        return articleService.lookupByNicknameAndTitle(likedUser, nickname, title);
+            @LoginOptional User user, @PathVariable String nickname, @PathVariable String title) {
+        return articleService.lookupByNicknameAndTitle(user, nickname, title);
     }
 
     @Operation(summary = "블로그 글 수정")

--- a/src/main/java/kr/co/finote/backend/src/article/dto/response/ArticleResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/article/dto/response/ArticleResponse.java
@@ -17,8 +17,9 @@ public class ArticleResponse {
     private String authorNickname;
     private String profileImageUrl;
     private Boolean isLiked;
+    private Boolean isFollowed;
 
-    public static ArticleResponse of(Article article, boolean isLiked) {
+    public static ArticleResponse of(Article article, boolean isLiked, boolean isFollowed) {
         return ArticleResponse.builder()
                 .id(article.getId())
                 .title(article.getTitle())
@@ -28,6 +29,7 @@ public class ArticleResponse {
                 .profileImageUrl(article.getUser().getProfileImageUrl())
                 .createDate(article.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
                 .isLiked(isLiked)
+                .isFollowed(isFollowed)
                 .build();
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -19,6 +19,7 @@ import kr.co.finote.backend.src.article.dto.request.DragArticleRequest;
 import kr.co.finote.backend.src.article.dto.response.*;
 import kr.co.finote.backend.src.article.repository.ArticleEsRepository;
 import kr.co.finote.backend.src.article.repository.ArticleRepository;
+import kr.co.finote.backend.src.common.service.FollowService;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -51,6 +52,7 @@ public class ArticleService {
     private final UserService userService;
     private final CacheService cacheService;
     private final ArticleLikeService articleLikeService;
+    private final FollowService followService;
 
     @Transactional
     public PostArticleResponse save(ArticleRequest articleRequest, User loginUser)
@@ -77,31 +79,33 @@ public class ArticleService {
     }
 
     @Transactional
-    public ArticleResponse lookupById(User likedUser, Long articleId) {
+    public ArticleResponse lookupById(User user, Long articleId) {
         Article article =
                 articleRepository
                         .findByIdAndIsDeleted(articleId, false)
                         .orElseThrow(() -> new NotFoundException(ResponseCode.ARTICLE_NOT_FOUND));
-        boolean isLiked = false;
-        if (likedUser != null) {
-            ArticleLikeCache articleLikeCache = cacheService.findLikelog(likedUser, article);
-            isLiked = articleLikeCache != null && !articleLikeCache.getIsDeleted();
-        }
 
-        return ArticleResponse.of(article, isLiked);
+        // Front-end와 협의 결과 글 수정시에만 사용되기 때문에 상수 값 전달
+        return ArticleResponse.of(article, false, false);
     }
 
     @Transactional
-    public ArticleResponse lookupByNicknameAndTitle(User likedUser, String nickname, String title) {
+    public ArticleResponse lookupByNicknameAndTitle(User user, String nickname, String title) {
         Article article = findByNicknameAndTitle(nickname, title);
 
         boolean isLiked = false;
-        if (likedUser != null) {
-            ArticleLikeCache articleLikeCache = cacheService.findLikelog(likedUser, article);
+        if (user != null) {
+            ArticleLikeCache articleLikeCache = cacheService.findLikelog(user, article);
             isLiked = articleLikeCache != null && !articleLikeCache.getIsDeleted();
         }
 
-        return ArticleResponse.of(article, isLiked);
+        boolean isFollowed = false;
+        if (user != null) {
+            User byNickname = userService.findByNickname(nickname);
+            isFollowed = followService.isFollowed(user, byNickname);
+        }
+
+        return ArticleResponse.of(article, isLiked, isFollowed);
     }
 
     public ArticlePreviewListResponse getDragRelatedArticle(

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -101,8 +101,8 @@ public class ArticleService {
 
         boolean isFollowed = false;
         if (user != null) {
-            User byNickname = userService.findByNickname(nickname);
-            isFollowed = followService.isFollowed(user, byNickname);
+            User authorUser = userService.findByNickname(nickname);
+            isFollowed = followService.isFollowed(user, authorUser);
         }
 
         return ArticleResponse.of(article, isLiked, isFollowed);

--- a/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
+++ b/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
@@ -88,6 +88,13 @@ public class FollowService {
         return FollowUserListResponse.of(followUserResponses);
     }
 
+    public boolean isFollowed(User fromUser, User toUser) {
+        return followInfoRepository
+                .findByFromUserAndToUser(fromUser, toUser)
+                .map(followInfo -> !followInfo.getIsDeleted())
+                .orElse(false);
+    }
+
     private List<FollowUserResponse> FollowerUserList(List<FollowInfo> followInfos) {
         return followInfos.stream()
                 .map(followInfo -> FollowUserResponse.of(followInfo.getFromUser()))


### PR DESCRIPTION
### ✍🏻 개요
글 조회 시 글 작성자에 대한 팔로우 여부를 알 수 있어야 합니다. 이를 위해 글 조회 API를 수정하였습니다.
<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- ArticleResponse DTO에 isFollowed 필드 추가
- 비로그인, 팔로우 상태를 고려한 isFollowed 값 결정
- 범용성을 위해 @Liked → @LoginOptional 로 이름 변경 (역할은 동일)
- 우선 캐시는 적용하지 않음.

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
