### PR TITLE
[FIN-265] 추가 정보 설정 API 수정하기

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
@@ -3,7 +3,6 @@ package kr.co.finote.backend.src.user.api;
 import io.swagger.v3.oas.annotations.Operation;
 import javax.validation.Valid;
 import kr.co.finote.backend.global.annotation.Login;
-import kr.co.finote.backend.global.authentication.PrincipalDetails;
 import kr.co.finote.backend.src.article.dto.response.ArticlePreviewListResponse;
 import kr.co.finote.backend.src.article.service.ArticleLikeService;
 import kr.co.finote.backend.src.user.domain.User;
@@ -16,8 +15,6 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -66,10 +63,8 @@ public class UserApi {
     /* API related to additional-info */
     @Operation(summary = "추가 정보 입력")
     @PostMapping("/additional-info")
-    public void additionalInfo(@RequestBody @Valid AdditionalInfoRequest request) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
-        User loginUser = principal.getUser();
+    public void additionalInfo(
+            @Login User loginUser, @RequestBody @Valid AdditionalInfoRequest request) {
         userService.editAdditionalInfo(loginUser, request);
     }
 

--- a/src/main/java/kr/co/finote/backend/src/user/domain/User.java
+++ b/src/main/java/kr/co/finote/backend/src/user/domain/User.java
@@ -67,7 +67,7 @@ public class User extends BaseEntity {
     public void updateAdditionalInfo(AdditionalInfoRequest additionalInfoRequest) {
         this.nickname = additionalInfoRequest.getNickname();
         this.blogName = additionalInfoRequest.getBlogName();
-        this.blogUrl = additionalInfoRequest.getBlogUrl();
+        this.profileImageUrl = additionalInfoRequest.getProfileImageUrl();
     }
 
     public void updateRefreshToken(String refreshToken) {

--- a/src/main/java/kr/co/finote/backend/src/user/dto/request/AdditionalInfoRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/request/AdditionalInfoRequest.java
@@ -6,15 +6,12 @@ import lombok.Getter;
 @Getter
 public class AdditionalInfoRequest {
 
-    @NotBlank(message = "프로필 이미지 url을 입력해주세요.")
-    private String profileImage;
+    // TODO : finote의 기본 프사 S3링크를 @Default로 설정하기
+    private String profileImageUrl;
 
     @NotBlank(message = "닉네임을 입력해주세요.")
     private String nickname;
 
     @NotBlank(message = "블로그 이름을 입력해주세요.")
     private String blogName;
-
-    @NotBlank(message = "블로그 url을 입력해주세요.")
-    private String blogUrl;
 }

--- a/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
@@ -3,7 +3,6 @@ package kr.co.finote.backend.src.user.service;
 import kr.co.finote.backend.global.code.ResponseCode;
 import kr.co.finote.backend.global.exception.InvalidInputException;
 import kr.co.finote.backend.global.exception.NotFoundException;
-import kr.co.finote.backend.global.exception.UnAuthorizedException;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.dto.request.AdditionalInfoRequest;
 import kr.co.finote.backend.src.user.repository.UserRepository;
@@ -53,12 +52,11 @@ public class UserService {
     public void editAdditionalInfo(User user, AdditionalInfoRequest request) {
         validateNickname(request.getNickname());
         validateBlogName(request.getBlogName());
-        validateBlogUrl(request.getBlogUrl());
 
         User findUser =
                 userRepository
                         .findByIdAndIsDeleted(user.getId(), false)
-                        .orElseThrow(() -> new UnAuthorizedException(ResponseCode.UNAUTHENTICATED));
+                        .orElseThrow(() -> new NotFoundException(ResponseCode.USER_NOT_FOUND));
 
         findUser.updateAdditionalInfo(request);
     }


### PR DESCRIPTION
### ✍🏻 개요
FIN-265에 대한 구현입니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 블로그 URL 필드 삭제
- 프로필이미지 url 필드 추가
- 프로필이미지 @Notblank 검증 삭제

<br>

### 👥 To Reviewers
기획 페이지를 고려했을 때, 프로필 사진은 언제나 추가 정보 설정에서만 바꿀 수 있습니다.
이를 반영하여 프로필 사진만을 바꾸는 별도의 API가 아닌 추가 정보 설정 API에서 처리할 수 있도록 했습니다.

추가로 팀 의논 결과 블로그 URL 필드는 삭제하기로 되어, 이를 반영하였습니다.

profileImage에 있던 @Notblank의 경우 기본 프로필사진인 경우 null, 빈 스트링이 올때 오류가 발생할 것 같아 일단 없앴고,
추후 기본 이미지 S3링크를 @Default로 하는 건 어떨까요?