### PR TITLE
hotfix: elasticsearch connection 에러 해결 시도

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/config/ElasticSearchTester.java
+++ b/src/main/java/kr/co/finote/backend/global/config/ElasticSearchTester.java
@@ -13,7 +13,7 @@ public class ElasticSearchTester {
 
     private final ArticleEsRepository articleEsRepository;
 
-    @Scheduled(fixedDelay = 100000, initialDelay = 100000)
+    @Scheduled(fixedDelay = 10000, initialDelay = 10000)
     public void keepConnectionAlive() {
         log.info("ElasticSearch Connection Alive");
         try {


### PR DESCRIPTION
### ✍🏻 개요
Private subnet EC2 -> NAT gateway의 트래픽이 일정 시간 (350sec) 동안 응답이 없는 경우 idle connection으로 전환합니다.
이를 방지하기 위한 코드를 추가합니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
keep-alive 연결 유지를 위한 요청을 10초로 줄임.


<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
