### PR TITLE
hotfix: Prod환경의 ElasticSearch Connection 에러 해결 시도

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/config/ElasticSearchTester.java
+++ b/src/main/java/kr/co/finote/backend/global/config/ElasticSearchTester.java
@@ -1,6 +1,6 @@
 package kr.co.finote.backend.global.config;
 
-import kr.co.finote.backend.src.article.repository.ArticleEsRepository;
+import kr.co.finote.backend.src.article.service.ElasticService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -11,14 +11,14 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class ElasticSearchTester {
 
-    private final ArticleEsRepository articleEsRepository;
+    private final ElasticService elasticService;
 
-    @Scheduled(fixedDelay = 10000, initialDelay = 10000)
+    @Scheduled(fixedDelay = 45000, initialDelay = 10000)
     public void keepConnectionAlive() {
         log.info("ElasticSearch Connection Alive");
         try {
-            long count = articleEsRepository.count();
-            log.info("ElasticSearch Connection Count : {}", count);
+            elasticService.search("");
+            log.info("ElasticSearchRestTemplate.search()..");
         } catch (Exception e) {
             log.error("ElasticSearch Connection Error");
         }

--- a/src/main/java/kr/co/finote/backend/global/config/ElasticSearchTester.java
+++ b/src/main/java/kr/co/finote/backend/global/config/ElasticSearchTester.java
@@ -13,7 +13,7 @@ public class ElasticSearchTester {
 
     private final ArticleEsRepository articleEsRepository;
 
-    @Scheduled(fixedDelay = 100000, initialDelay = 100000)
+    @Scheduled(fixedDelay = 10000, initialDelay = 10000)
     public void keepConnectionAlive() {
         log.info("ElasticSearch Connection Alive");
         try {


### PR DESCRIPTION
### ✍🏻 개요
Prod 환경의 Private subnet EC2 의 ElasticSearch로의 TCP Connection이  idle로 전환됩니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
지속적으로 RestTemplate을 활용해 연결을 유지합니다.

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
