### PR TITLE
[FIN-297] feat: 내 팔로워, 팔로잉 수 조회 API

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/common/api/CommonApi.java
+++ b/src/main/java/kr/co/finote/backend/src/common/api/CommonApi.java
@@ -5,9 +5,7 @@ import kr.co.finote.backend.global.annotation.Login;
 import kr.co.finote.backend.src.article.dto.response.ArticlePreviewListResponse;
 import kr.co.finote.backend.src.article.service.ArticleService;
 import kr.co.finote.backend.src.common.dto.request.FileUploadRequest;
-import kr.co.finote.backend.src.common.dto.response.FollowResultResponse;
-import kr.co.finote.backend.src.common.dto.response.FollowUserListResponse;
-import kr.co.finote.backend.src.common.dto.response.PresignedUrlResponse;
+import kr.co.finote.backend.src.common.dto.response.*;
 import kr.co.finote.backend.src.common.service.FollowService;
 import kr.co.finote.backend.src.common.service.S3Service;
 import kr.co.finote.backend.src.user.domain.User;
@@ -63,5 +61,17 @@ public class CommonApi {
     @PostMapping("/pre-signed-url")
     public PresignedUrlResponse getPreSignedUrl(@RequestBody FileUploadRequest request) {
         return s3Service.getPresignedUrl(request);
+    }
+
+    @Operation(summary = "팔로워 수")
+    @GetMapping("/followers/count")
+    public FollowersCountResponse getFollowerCount(@Login User loginUser) {
+        return followService.followersCount(loginUser);
+    }
+
+    @Operation(summary = "팔로잉 수")
+    @GetMapping("/followings/count")
+    public FollowingsCountResponse getFollowingCount(@Login User loginUser) {
+        return followService.followingsCount(loginUser);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/common/dto/response/FollowersCountResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/common/dto/response/FollowersCountResponse.java
@@ -1,0 +1,14 @@
+package kr.co.finote.backend.src.common.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class FollowersCountResponse {
+    private int count;
+
+    public static FollowersCountResponse createFollowersResponse(int count) {
+        return FollowersCountResponse.builder().count(count).build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/common/dto/response/FollowingsCountResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/common/dto/response/FollowingsCountResponse.java
@@ -1,0 +1,15 @@
+package kr.co.finote.backend.src.common.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class FollowingsCountResponse {
+
+    private int count;
+
+    public static FollowingsCountResponse createFollowingsResponse(int count) {
+        return FollowingsCountResponse.builder().count(count).build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/common/repository/FollowInfoRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/common/repository/FollowInfoRepository.java
@@ -20,4 +20,8 @@ public interface FollowInfoRepository extends JpaRepository<FollowInfo, Long> {
     @Query(
             "select fi from FollowInfo fi join fetch fi.fromUser WHERE fi.toUser = :toUser AND fi.isDeleted = false")
     List<FollowInfo> findAllWithToUser(@Param("toUser") User toUser);
+
+    int countByToUserAndIsDeleted(User toUser, boolean isDeleted);
+
+    int countByFromUserAndIsDeleted(User fromUser, boolean isDeleted);
 }

--- a/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
+++ b/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
@@ -6,9 +6,7 @@ import java.util.stream.Collectors;
 import kr.co.finote.backend.global.code.ResponseCode;
 import kr.co.finote.backend.global.exception.InvalidInputException;
 import kr.co.finote.backend.src.common.domain.FollowInfo;
-import kr.co.finote.backend.src.common.dto.response.FollowResultResponse;
-import kr.co.finote.backend.src.common.dto.response.FollowUserListResponse;
-import kr.co.finote.backend.src.common.dto.response.FollowUserResponse;
+import kr.co.finote.backend.src.common.dto.response.*;
 import kr.co.finote.backend.src.common.repository.FollowInfoRepository;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.service.UserService;
@@ -93,6 +91,17 @@ public class FollowService {
                 .findByFromUserAndToUser(fromUser, toUser)
                 .map(followInfo -> !followInfo.getIsDeleted())
                 .orElse(false);
+    }
+
+    public FollowersCountResponse followersCount(User user) {
+
+        return FollowersCountResponse.createFollowersResponse(
+                followInfoRepository.countByToUserAndIsDeleted(user, false));
+    }
+
+    public FollowingsCountResponse followingsCount(User user) {
+        return FollowingsCountResponse.createFollowingsResponse(
+                followInfoRepository.countByFromUserAndIsDeleted(user, false));
     }
 
     private List<FollowUserResponse> FollowerUserList(List<FollowInfo> followInfos) {


### PR DESCRIPTION
### ✍🏻 개요
내 팔로워, 팔로잉 수 조회 API 구현

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 내 팔로워, 팔로잉 수 조회 API 구현

<br>

### 👥 To Reviewers
- 다른 유저의 팔로잉, 팔로워 수 구현도 추후에 필요할 것 같습니다!
