### PR TITLE
[FIN-310] feat: 유저에 대한 팔로우 여부 API 구현

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/dto/response/ArticleResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/article/dto/response/ArticleResponse.java
@@ -16,10 +16,8 @@ public class ArticleResponse {
     private String authorId;
     private String authorNickname;
     private String profileImageUrl;
-    private Boolean isLiked;
-    private Boolean isFollowed;
 
-    public static ArticleResponse of(Article article, boolean isLiked, boolean isFollowed) {
+    public static ArticleResponse of(Article article) {
         return ArticleResponse.builder()
                 .id(article.getId())
                 .title(article.getTitle())
@@ -28,8 +26,6 @@ public class ArticleResponse {
                 .authorNickname(article.getUser().getNickname())
                 .profileImageUrl(article.getUser().getProfileImageUrl())
                 .createDate(article.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
-                .isLiked(isLiked)
-                .isFollowed(isFollowed)
                 .build();
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -85,27 +85,14 @@ public class ArticleService {
                         .findByIdAndIsDeleted(articleId, false)
                         .orElseThrow(() -> new NotFoundException(ResponseCode.ARTICLE_NOT_FOUND));
 
-        // Front-end와 협의 결과 글 수정시에만 사용되기 때문에 상수 값 전달
-        return ArticleResponse.of(article, false, false);
+        return ArticleResponse.of(article);
     }
 
     @Transactional
     public ArticleResponse lookupByNicknameAndTitle(User user, String nickname, String title) {
         Article article = findByNicknameAndTitle(nickname, title);
 
-        boolean isLiked = false;
-        if (user != null) {
-            ArticleLikeCache articleLikeCache = cacheService.findLikelog(user, article);
-            isLiked = articleLikeCache != null && !articleLikeCache.getIsDeleted();
-        }
-
-        boolean isFollowed = false;
-        if (user != null) {
-            User authorUser = userService.findByNickname(nickname);
-            isFollowed = followService.isFollowed(user, authorUser);
-        }
-
-        return ArticleResponse.of(article, isLiked, isFollowed);
+        return ArticleResponse.of(article);
     }
 
     public ArticlePreviewListResponse getDragRelatedArticle(

--- a/src/main/java/kr/co/finote/backend/src/common/api/CommonApi.java
+++ b/src/main/java/kr/co/finote/backend/src/common/api/CommonApi.java
@@ -3,6 +3,7 @@ package kr.co.finote.backend.src.common.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.finote.backend.global.annotation.Login;
+import kr.co.finote.backend.global.annotation.LoginOptional;
 import kr.co.finote.backend.src.article.dto.response.ArticlePreviewListResponse;
 import kr.co.finote.backend.src.article.service.ArticleService;
 import kr.co.finote.backend.src.common.dto.request.FileUploadRequest;
@@ -81,5 +82,12 @@ public class CommonApi {
     @GetMapping("/followers/count/{nickname}")
     public FollowersCountResponse getFollowingCount(@PathVariable String nickname) {
         return followService.followersCount(nickname);
+    }
+
+    @Operation(summary = "유저에 대한 팔로우 여부 체크")
+    @GetMapping("/check-follow/{nickname}")
+    public FollowerCheckResponse checkFollow(
+            @LoginOptional User loginUser, @PathVariable String nickname) {
+        return followService.checkFollow(loginUser, nickname);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/common/dto/response/FollowerCheckResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/common/dto/response/FollowerCheckResponse.java
@@ -1,0 +1,17 @@
+package kr.co.finote.backend.src.common.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class FollowerCheckResponse {
+
+    boolean isFollowed;
+
+    public static FollowerCheckResponse createFollowerCheckResponse(boolean isFollowed) {
+        return FollowerCheckResponse.builder().isFollowed(isFollowed).build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
+++ b/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
@@ -109,17 +109,17 @@ public class FollowService {
                 followInfoRepository.countByFromUserAndIsDeleted(user, false));
     }
 
-    public FollowerCheckResponse checkFollow(User fromUser, String nickname) {
+    public FollowerCheckResponse checkFollow(User reader, String nickname) {
         // 비로그인 유저에 대한 처리
-        if (fromUser == null) {
+        if (reader == null) {
             return FollowerCheckResponse.createFollowerCheckResponse(false);
         }
 
-        User toUser = userService.findByNickname(nickname);
+        User author = userService.findByNickname(nickname);
 
         boolean isFollowed =
                 followInfoRepository
-                        .findByFromUserAndToUser(fromUser, toUser)
+                        .findByFromUserAndToUser(reader, author)
                         .filter(followInfo -> !followInfo.getIsDeleted())
                         .isPresent();
 

--- a/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
+++ b/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
@@ -109,6 +109,23 @@ public class FollowService {
                 followInfoRepository.countByFromUserAndIsDeleted(user, false));
     }
 
+    public FollowerCheckResponse checkFollow(User fromUser, String nickname) {
+        // 비로그인 유저에 대한 처리
+        if (fromUser == null) {
+            return FollowerCheckResponse.createFollowerCheckResponse(false);
+        }
+
+        User toUser = userService.findByNickname(nickname);
+
+        boolean isFollowed =
+                followInfoRepository
+                        .findByFromUserAndToUser(fromUser, toUser)
+                        .filter(followInfo -> !followInfo.getIsDeleted())
+                        .isPresent();
+
+        return FollowerCheckResponse.createFollowerCheckResponse(isFollowed);
+    }
+
     private List<FollowUserResponse> FollowerUserList(List<FollowInfo> followInfos) {
         return followInfos.stream()
                 .map(followInfo -> FollowUserResponse.of(followInfo.getFromUser()))


### PR DESCRIPTION
### ✍🏻 개요
글 조회의 경우 프론트에서 SSR로 구성하고 있습니다. 이에 따라 기존에 글 조회 시 내려주던 작성자의 팔로우 여부가 제대로 동작하지 않습니다.
이를 위한 별도의 API 엔드포인트를 설정하여 프론트가 클라이언트 사이드에서 API를 호출할 수 있도록 합니다.
<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 기존 글 조회 로직에서 팔로우 여부, 좋아요 여부 로직 삭제
- ArticleResponse 에서 관련 필드 삭제

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
