### PR TITLE
[FIN-307] feat: 특정 글에 대한 유저의 좋아요 여부 확인 API

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
+++ b/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
@@ -50,8 +50,8 @@ public class ArticleApi {
     @Operation(summary = "블로그 작성자 닉네임, 글 제목으로 조회")
     @GetMapping("/{nickname}/{title}")
     public ArticleResponse getArticleByNicknameAndTitle(
-            @LoginOptional User user, @PathVariable String nickname, @PathVariable String title) {
-        return articleService.lookupByNicknameAndTitle(user, nickname, title);
+            @PathVariable String nickname, @PathVariable String title) {
+        return articleService.lookupByNicknameAndTitle(nickname, title);
     }
 
     @Operation(summary = "블로그 글 수정")
@@ -109,5 +109,12 @@ public class ArticleApi {
             @Login User loginUser, @PathVariable String nickname, @PathVariable String title) {
         Article article = articleService.findByNicknameAndTitle(nickname, title);
         return articleService.postLikeByNicknameAndTitle(loginUser, article);
+    }
+
+    @Operation(summary = "독자의 글에 대한 좋아요 여부 확인")
+    @GetMapping("/check-like/{nickname}/{title}")
+    public ArticleLikeCheckResponse checkLike(
+            @LoginOptional User user, @PathVariable String nickname, @PathVariable String title) {
+        return articleService.checkLike(user, nickname, title);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/dto/response/ArticleLikeCheckResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/article/dto/response/ArticleLikeCheckResponse.java
@@ -1,0 +1,16 @@
+package kr.co.finote.backend.src.article.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class ArticleLikeCheckResponse {
+    private boolean isLiked;
+
+    public static ArticleLikeCheckResponse createArticleLikeCheckResponse(boolean isLiked) {
+        return ArticleLikeCheckResponse.builder().isLiked(isLiked).build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -89,7 +89,7 @@ public class ArticleService {
     }
 
     @Transactional
-    public ArticleResponse lookupByNicknameAndTitle(User user, String nickname, String title) {
+    public ArticleResponse lookupByNicknameAndTitle(String nickname, String title) {
         Article article = findByNicknameAndTitle(nickname, title);
 
         return ArticleResponse.of(article);
@@ -257,5 +257,18 @@ public class ArticleService {
         return articleRepository
                 .findByUserAndTitleAndIsDeleted(findUser, title, false)
                 .orElseThrow(() -> new NotFoundException(ResponseCode.ARTICLE_NOT_FOUND));
+    }
+
+    public ArticleLikeCheckResponse checkLike(User reader, String authorNickname, String title) {
+        if (reader == null) {
+            return ArticleLikeCheckResponse.createArticleLikeCheckResponse(false);
+        }
+
+        Article article = findByNicknameAndTitle(authorNickname, title);
+        ArticleLikeCache likelog = cacheService.findLikelog(reader, article);
+
+        boolean isLiked = (likelog == null || likelog.getIsDeleted()) ? false : true;
+
+        return ArticleLikeCheckResponse.createArticleLikeCheckResponse(isLiked);
     }
 }


### PR DESCRIPTION
### ✍🏻 개요
글 조회의 경우 프론트에서 SSR로 구성하고 있습니다. 이에 따라 기존에 글 조회 시 내려주던 독자의 글에 대한 좋아요 여부가 
제대로 동작하지 않습니다. 이를 위한 별도의 API 엔드포인트를 설정하여 프론트가 클라이언트 사이드에서 API를 호출할 수 있도록 합니다.
<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 조회 시 필요하지 않은 User 파라미터 제거
- 특정 글의 좋아요 여부 API 분리
- Redis 캐싱 적용

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
