### PR TITLE
[FIN-268] feat: 이메일 인증 코드 발송 및 검증 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 	//S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.281'
+
+	// email code
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/finote/backend/global/annotation/ValidEmail.java
+++ b/src/main/java/kr/co/finote/backend/global/annotation/ValidEmail.java
@@ -1,0 +1,20 @@
+package kr.co.finote.backend.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import kr.co.finote.backend.global.annotation.validator.EmailValidator;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EmailValidator.class)
+public @interface ValidEmail {
+
+    String message() default "@을 포함한 올바른 이메일 형식을 입력해주세요.";
+
+    Class[] groups() default {};
+
+    Class[] payload() default {};
+}

--- a/src/main/java/kr/co/finote/backend/global/annotation/validator/EmailValidator.java
+++ b/src/main/java/kr/co/finote/backend/global/annotation/validator/EmailValidator.java
@@ -1,0 +1,15 @@
+package kr.co.finote.backend.global.annotation.validator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import kr.co.finote.backend.global.annotation.ValidEmail;
+
+public class EmailValidator implements ConstraintValidator<ValidEmail, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
+        return value.matches("^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$");
+    }
+}

--- a/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
+++ b/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
@@ -25,6 +25,7 @@ public enum ResponseCode {
     BLOG_NAME_TOO_LONG(BAD_REQUEST, "400_BLOG_NAME_TOO_LONG", "블로그명은 100자 이하로 입력해주세요."),
     DUPLICATE_BLOG_URL(BAD_REQUEST, "400_DUPLICATE_BLOG_URL", "중복된 블로그 url 입니다."),
     BLOG_URL_TOO_LONG(BAD_REQUEST, "400_BLOG_URL_TOO_LONG", "블로그 url은 100자 이하로 입력해주세요."),
+    EMAIL_SENDING_FAILED(BAD_REQUEST, "400_EMAIL_SENDING_FAILED", "이메일 전송에 실패했습니다."),
 
     /** article error */
     ARTICLE_NOT_FOUND(NOT_FOUND, "404_ARTICLE_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."),

--- a/src/main/java/kr/co/finote/backend/global/config/RedisCacheConfig.java
+++ b/src/main/java/kr/co/finote/backend/global/config/RedisCacheConfig.java
@@ -28,6 +28,16 @@ public class RedisCacheConfig {
                 .build();
     }
 
+    @Bean
+    public CacheManager emailCodeManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration =
+                generateCacheConfiguration().entryTtl(Duration.ofMinutes(5));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+
     private RedisCacheConfiguration generateCacheConfiguration() {
         return RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(

--- a/src/main/java/kr/co/finote/backend/global/utils/StringUtils.java
+++ b/src/main/java/kr/co/finote/backend/global/utils/StringUtils.java
@@ -46,4 +46,13 @@ public class StringUtils {
             return doc.text().substring(0, PREVIEW_TEXT_MAX_LENGTH);
         else return doc.text();
     }
+
+    public static String makeRandom6Number() {
+        StringBuilder randomString = new StringBuilder();
+        for (int i = 0; i < 6; i++) {
+            int random = (int) (Math.random() * 10);
+            randomString.append(random);
+        }
+        return randomString.toString();
+    }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleLikeCacheService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleLikeCacheService.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class CacheService {
+public class ArticleLikeCacheService {
 
     private final ArticleLikeRepository articleLikeRepository;
 
@@ -24,7 +24,7 @@ public class CacheService {
             value = "ArticleLikeLog",
             cacheManager = "articleLikeManager")
     @Transactional
-    public ArticleLikeCache findLikelog(User user, Article article) {
+    public ArticleLikeCache findLikeLog(User user, Article article) {
         log.info("not cached");
         Optional<ArticleLike> articleLike = articleLikeRepository.findByUserAndArticle(user, article);
         return articleLike.map(ArticleLikeCache::of).orElse(null);

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -50,7 +50,7 @@ public class ArticleService {
     private final ArticleKeywordService articleKeywordService;
     private final ElasticService elasticService;
     private final UserService userService;
-    private final CacheService cacheService;
+    private final ArticleLikeCacheService articleLikeCacheService;
     private final ArticleLikeService articleLikeService;
     private final FollowService followService;
 
@@ -197,7 +197,7 @@ public class ArticleService {
     @CacheEvict(key = "#user.id + '-' + #article.id", value = "ArticleLikeLog")
     @Transactional
     public LikeResponse postLikeByNicknameAndTitle(User user, Article article) {
-        ArticleLikeCache articleLikeCache = cacheService.findLikelog(user, article);
+        ArticleLikeCache articleLikeCache = articleLikeCacheService.findLikeLog(user, article);
 
         Optional<ArticleLike> byUserAndArticle = articleLikeService.findByUser(user, article);
 

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -265,7 +265,7 @@ public class ArticleService {
         }
 
         Article article = findByNicknameAndTitle(authorNickname, title);
-        ArticleLikeCache likelog = cacheService.findLikelog(reader, article);
+        ArticleLikeCache likelog = articleLikeCacheService.findLikeLog(reader, article);
 
         boolean isLiked = (likelog == null || likelog.getIsDeleted()) ? false : true;
 

--- a/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
@@ -9,6 +9,7 @@ import kr.co.finote.backend.src.article.service.ArticleLikeService;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.dto.request.*;
 import kr.co.finote.backend.src.user.dto.response.BlogResponse;
+import kr.co.finote.backend.src.user.dto.response.EmailCodeValidationResponse;
 import kr.co.finote.backend.src.user.dto.response.LikeCountResponse;
 import kr.co.finote.backend.src.user.dto.response.NicknameResponse;
 import kr.co.finote.backend.src.user.service.UserService;
@@ -30,6 +31,20 @@ public class UserApi {
     ArticleLikeService articleLikeService;
 
     /* Field Validation API */
+
+    @Operation(summary = "이메일 인증 코드 발송")
+    @PostMapping(value = "/issue/email-code")
+    public void sendEmailCode(@RequestBody @Valid EmailCodeRequest request) {
+        userService.issueEmailCode(request);
+    }
+
+    @Operation(summary = "이메일 인증 코드 확인")
+    @PostMapping(value = "/validation/email-code")
+    public EmailCodeValidationResponse validateEmailCode(
+            @RequestBody @Valid EmailCodeValidationRequest request) {
+        return userService.validateEmailCode(request);
+    }
+
     @Operation(summary = "닉네임 중복 검사")
     @PostMapping(value = "/validation/nickname")
     public void validateNickname(@RequestBody @Valid NicknameDuplicateCheckRequest request) {

--- a/src/main/java/kr/co/finote/backend/src/user/dto/request/EmailCodeRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/request/EmailCodeRequest.java
@@ -1,0 +1,13 @@
+package kr.co.finote.backend.src.user.dto.request;
+
+import javax.validation.constraints.NotNull;
+import kr.co.finote.backend.global.annotation.ValidEmail;
+import lombok.Getter;
+
+@Getter
+public class EmailCodeRequest {
+
+    @NotNull(message = "이메일이 입력되지 않았습니다.")
+    @ValidEmail
+    private String email;
+}

--- a/src/main/java/kr/co/finote/backend/src/user/dto/request/EmailCodeValidationRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/request/EmailCodeValidationRequest.java
@@ -1,0 +1,10 @@
+package kr.co.finote.backend.src.user.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class EmailCodeValidationRequest {
+
+    private String email;
+    private String code;
+}

--- a/src/main/java/kr/co/finote/backend/src/user/dto/response/EmailCodeValidationResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/response/EmailCodeValidationResponse.java
@@ -1,0 +1,15 @@
+package kr.co.finote.backend.src.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class EmailCodeValidationResponse {
+
+    private boolean isValid;
+
+    public static EmailCodeValidationResponse createEmailValidationResponse(boolean isValid) {
+        return EmailCodeValidationResponse.builder().isValid(isValid).build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/user/service/EmailCodeCacheService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/EmailCodeCacheService.java
@@ -2,6 +2,7 @@ package kr.co.finote.backend.src.user.service;
 
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -12,10 +13,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EmailCodeCacheService {
 
-    private final CacheManager cacheManager;
+    @Qualifier("emailCodeManager")
+    private final CacheManager emailCodeManager;
 
     public String findEmailCode(String email) {
-        return Objects.requireNonNull(cacheManager.getCache("EmailCode")).get(email, String.class);
+        return Objects.requireNonNull(emailCodeManager.getCache("EmailCode")).get(email, String.class);
     }
 
     @Cacheable(key = "#email", value = "EmailCode", cacheManager = "emailCodeManager")

--- a/src/main/java/kr/co/finote/backend/src/user/service/EmailCodeCacheService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/EmailCodeCacheService.java
@@ -1,0 +1,29 @@
+package kr.co.finote.backend.src.user.service;
+
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EmailCodeCacheService {
+
+    private final CacheManager cacheManager;
+
+    public String findEmailCode(String email) {
+        return Objects.requireNonNull(cacheManager.getCache("EmailCode")).get(email, String.class);
+    }
+
+    @Cacheable(key = "#email", value = "EmailCode", cacheManager = "emailCodeManager")
+    @Transactional
+    public String cacheEmailCode(String email, String code) {
+        return code;
+    }
+
+    @CacheEvict(key = "#email", value = "EmailCode", cacheManager = "emailCodeManager")
+    public void evictEmailCode(String email) {}
+}

--- a/src/main/java/kr/co/finote/backend/src/user/service/MailService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/MailService.java
@@ -1,0 +1,36 @@
+package kr.co.finote.backend.src.user.service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import kr.co.finote.backend.global.code.ResponseCode;
+import kr.co.finote.backend.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+    private static final String SENDER_EMAIL = "swm.meteor@gmail.com";
+
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    public void sendMail(String title, String recipients, String body) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        try {
+            mimeMessage.setFrom(SENDER_EMAIL);
+            mimeMessage.setRecipients(MimeMessage.RecipientType.TO, recipients);
+            mimeMessage.setSubject(title);
+            mimeMessage.setText(body, "UTF-8", "html");
+            javaMailSender.send(mimeMessage);
+        } catch (MailSendException | MessagingException e) {
+            throw new CustomException(ResponseCode.EMAIL_SENDING_FAILED);
+        } catch (Exception e) {
+            throw new CustomException(ResponseCode.INTERNAL_ERROR);
+        }
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
@@ -3,8 +3,12 @@ package kr.co.finote.backend.src.user.service;
 import kr.co.finote.backend.global.code.ResponseCode;
 import kr.co.finote.backend.global.exception.InvalidInputException;
 import kr.co.finote.backend.global.exception.NotFoundException;
+import kr.co.finote.backend.global.utils.StringUtils;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.dto.request.AdditionalInfoRequest;
+import kr.co.finote.backend.src.user.dto.request.EmailCodeRequest;
+import kr.co.finote.backend.src.user.dto.request.EmailCodeValidationRequest;
+import kr.co.finote.backend.src.user.dto.response.EmailCodeValidationResponse;
 import kr.co.finote.backend.src.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +24,9 @@ public class UserService {
     public static final int BLOG_NAME_MAX_LENGTH = 100;
     public static final int BLOG_URL_MAX_LENGTH = 100;
     private final UserRepository userRepository;
+
+    private final MailService mailService;
+    private final EmailCodeCacheService emailCodeCacheService;
 
     public void validateNickname(String nickname) {
         boolean existsByNickname = userRepository.existsByNicknameAndIsDeleted(nickname, false);
@@ -77,5 +84,38 @@ public class UserService {
         return userRepository
                 .findByEmailAndIsDeleted(email, false)
                 .orElseThrow(() -> new NotFoundException(ResponseCode.USER_NOT_FOUND));
+    }
+
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    public void issueEmailCode(EmailCodeRequest request) {
+        String emailCode =
+                emailCodeCacheService.findEmailCode(request.getEmail()); // 캐시에 저장된 이메일 코드가 있는지 확인
+        if (emailCode != null)
+            emailCodeCacheService.evictEmailCode(request.getEmail()); // 기존에 발급받은 코드가 존재하면 무효화
+        String random6Number = StringUtils.makeRandom6Number();
+        log.info("random6Number: {}", random6Number);
+        String body = "";
+        body += "<h2>" + "FINOTE" + "</h2>";
+        body += "<p>" + "안녕하세요. FINOTE입니다." + "</p>";
+        body += "<p>" + "저희 홈페이지를 방문해주셔서 감사합니다." + "</p>";
+        body += "<p>" + "요청하신 인증 번호입니다." + "</p><br>";
+        body += "<h2>" + random6Number + "</h2><br>";
+        body += "<p>" + "회원가입 페이지로 돌아가서 인증번호를 입력해주세요." + "</p>";
+        body += "<p>" + "감사합니다." + "</p>";
+        mailService.sendMail("[FINOTE] 이메일 인증 코드입니다.", request.getEmail(), body);
+        emailCodeCacheService.cacheEmailCode(request.getEmail(), random6Number); // 새로운 이메일, 인증코드 데이터 캐시
+    }
+
+    public EmailCodeValidationResponse validateEmailCode(EmailCodeValidationRequest request) {
+        String emailCode =
+                emailCodeCacheService.findEmailCode(request.getEmail()); // 캐시에 저장된 이메일 코드가 있는지 확인
+        if (emailCode == null || !emailCode.equals(request.getCode()))
+            return EmailCodeValidationResponse.createEmailValidationResponse(
+                    false); // 캐시에 저장된 이메일 코드가 없으면 false 리턴
+        else {
+            emailCodeCacheService.evictEmailCode(
+                    request.getEmail()); // 캐시에 저장된 이메일 코드가 있고, 입력한 코드와 일치하면 캐시에서 삭제
+            return EmailCodeValidationResponse.createEmailValidationResponse(true); // true 리턴
+        }
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
@@ -90,8 +90,9 @@ public class UserService {
     public void issueEmailCode(EmailCodeRequest request) {
         String emailCode =
                 emailCodeCacheService.findEmailCode(request.getEmail()); // 캐시에 저장된 이메일 코드가 있는지 확인
-        if (emailCode != null)
+        if (emailCode != null) {
             emailCodeCacheService.evictEmailCode(request.getEmail()); // 기존에 발급받은 코드가 존재하면 무효화
+        }
         String random6Number = StringUtils.makeRandom6Number();
         log.info("random6Number: {}", random6Number);
         String body = "";

--- a/src/main/java/lombok.config
+++ b/src/main/java/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,27 @@ spring:
               - profile
               - email
 
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PORT}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          timeout: 5000
+          ssl:
+            trust: ${MAIL_HOST}
+            enable: true
+            required: true
+    protocol: smtp
+    default-encoding: UTF-8
+    test-connection: true
+
 springdoc:
   swagger-ui:
     path: /finote-api-docs
@@ -101,3 +122,4 @@ cloud:
       secret-key: ${S3_SECRET_KEY}
     stack:
       auto: false
+


### PR DESCRIPTION
### ✍🏻 개요
이메일 로그인 기능 중 이메일 인증 코드 전송 및 검증 기능 구현

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 이메일 인증 코드 임시 저장을 위해 redis 캐시 사용
- 이메일 인증코드 전송 및 인증코드 검증 API 구현
- email code를 저장하는 cache service가 생김에 따라 articleLikeCacheservice로 이름 변경
- 메일 전송을 위한 google SMTP 설정

<br>

### 👥 To Reviewers
관련 기능 구현 과정은 노션 문서에 정리해두었습니다 [문서링크](https://www.notion.so/soma-meteor/API-7c01f9137ab24cf78ec695d683e98933?pvs=4)
이메일 인증 후 실제로 가입하는 API는 추후 개발 예정입니다!
