### PR TITLE
hotfix/change-response-type-of-validation-api

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
@@ -8,10 +8,7 @@ import kr.co.finote.backend.src.article.dto.response.ArticlePreviewListResponse;
 import kr.co.finote.backend.src.article.service.ArticleLikeService;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.dto.request.*;
-import kr.co.finote.backend.src.user.dto.response.BlogResponse;
-import kr.co.finote.backend.src.user.dto.response.EmailCodeValidationResponse;
-import kr.co.finote.backend.src.user.dto.response.LikeCountResponse;
-import kr.co.finote.backend.src.user.dto.response.NicknameResponse;
+import kr.co.finote.backend.src.user.dto.response.*;
 import kr.co.finote.backend.src.user.service.UserService;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -53,15 +50,16 @@ public class UserApi {
     /* Field Validation API */
     @Operation(summary = "닉네임 중복 검사")
     @PostMapping(value = "/validation/nickname")
-    public void validateNickname(@RequestBody @Valid NicknameDuplicateCheckRequest request) {
-        userService.validateNickname(
-                request.getNickname()); // throws exception if nickname is invalid (e.g. duplicated)
+    public ValidationNicknameResponse validateNickname(
+            @RequestBody @Valid NicknameDuplicateCheckRequest request) {
+        return userService.validateNickname(request.getNickname());
     }
 
     @Operation(summary = "블로그 이름 중복 검사")
     @PostMapping(value = "/validation/blog-name")
-    public void validateBlogName(@RequestBody @Valid BlogNameDuplicateCheckRequest request) {
-        userService.validateBlogName(request.getBlogName());
+    public ValidationBlogNameResponse validateBlogName(
+            @RequestBody @Valid BlogNameDuplicateCheckRequest request) {
+        return userService.validateBlogName(request.getBlogName());
     }
 
     /* Field Getter API */

--- a/src/main/java/kr/co/finote/backend/src/user/dto/request/BlogNameDuplicateCheckRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/request/BlogNameDuplicateCheckRequest.java
@@ -1,11 +1,13 @@
 package kr.co.finote.backend.src.user.dto.request;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class BlogNameDuplicateCheckRequest {
 
     @NotBlank(message = "블로그 이름을 입력해주세요.")
+    @Size(max = 20, message = "블로그 이름은 20자 이하로 입력해주세요.")
     private String blogName;
 }

--- a/src/main/java/kr/co/finote/backend/src/user/dto/request/NicknameDuplicateCheckRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/request/NicknameDuplicateCheckRequest.java
@@ -1,11 +1,13 @@
 package kr.co.finote.backend.src.user.dto.request;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class NicknameDuplicateCheckRequest {
 
     @NotBlank(message = "닉네임을 입력해주세요.")
+    @Size(max = 10, message = "닉네임은 10자 이하로 입력해주세요.")
     private String nickname;
 }

--- a/src/main/java/kr/co/finote/backend/src/user/dto/response/ValidationBlogNameResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/response/ValidationBlogNameResponse.java
@@ -9,7 +9,7 @@ public class ValidationBlogNameResponse {
 
     private boolean isDuplicated;
 
-    public static ValidationBlogNameResponse createValidationBlogNameRResponse(boolean isDuplicated) {
+    public static ValidationBlogNameResponse createValidationBlogNameResponse(boolean isDuplicated) {
         return ValidationBlogNameResponse.builder().isDuplicated(isDuplicated).build();
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/dto/response/ValidationBlogNameResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/response/ValidationBlogNameResponse.java
@@ -1,0 +1,13 @@
+package kr.co.finote.backend.src.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public class ValidationBlogNameResponse {
+
+    private boolean isDuplicated;
+
+    public static ValidationBlogNameResponse createValidationBlogNameRResponse(boolean isDuplicated) {
+        return ValidationBlogNameResponse.builder().isDuplicated(isDuplicated).build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/user/dto/response/ValidationBlogNameResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/response/ValidationBlogNameResponse.java
@@ -1,8 +1,10 @@
 package kr.co.finote.backend.src.user.dto.response;
 
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
+@Getter
 public class ValidationBlogNameResponse {
 
     private boolean isDuplicated;

--- a/src/main/java/kr/co/finote/backend/src/user/dto/response/ValidationNicknameResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/response/ValidationNicknameResponse.java
@@ -9,7 +9,7 @@ public class ValidationNicknameResponse {
 
     private boolean isDuplicated;
 
-    public static ValidationNicknameResponse createValidationNicknameRResponse(boolean isDuplicated) {
+    public static ValidationNicknameResponse createValidationNicknameResponse(boolean isDuplicated) {
         return ValidationNicknameResponse.builder().isDuplicated(isDuplicated).build();
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/dto/response/ValidationNicknameResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/response/ValidationNicknameResponse.java
@@ -1,8 +1,10 @@
 package kr.co.finote.backend.src.user.dto.response;
 
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
+@Getter
 public class ValidationNicknameResponse {
 
     private boolean isDuplicated;

--- a/src/main/java/kr/co/finote/backend/src/user/dto/response/ValidationNicknameResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/response/ValidationNicknameResponse.java
@@ -1,0 +1,13 @@
+package kr.co.finote.backend.src.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public class ValidationNicknameResponse {
+
+    private boolean isDuplicated;
+
+    public static ValidationNicknameResponse createValidationNicknameRResponse(boolean isDuplicated) {
+        return ValidationNicknameResponse.builder().isDuplicated(isDuplicated).build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
@@ -35,18 +35,12 @@ public class UserService {
 
     public ValidationNicknameResponse validateNickname(String nickname) {
         boolean existsByNickname = userRepository.existsByNicknameAndIsDeleted(nickname, false);
-        if (existsByNickname) {
-            return ValidationNicknameResponse.createValidationNicknameRResponse(true);
-        }
-        return ValidationNicknameResponse.createValidationNicknameRResponse(false);
+        return ValidationNicknameResponse.createValidationNicknameResponse(existsByNickname);
     }
 
     public ValidationBlogNameResponse validateBlogName(String blogName) {
         boolean existsByBlogName = userRepository.existsByBlogNameAndIsDeleted(blogName, false);
-        if (existsByBlogName) {
-            return ValidationBlogNameResponse.createValidationBlogNameRResponse(true);
-        } // 그 외 금지문자 포함 등의 error 처리 예정
-        return ValidationBlogNameResponse.createValidationBlogNameRResponse(false);
+        return ValidationBlogNameResponse.createValidationBlogNameResponse(existsByBlogName);
     }
 
     @Transactional

--- a/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/UserService.java
@@ -10,6 +10,8 @@ import kr.co.finote.backend.src.user.dto.request.EmailCodeRequest;
 import kr.co.finote.backend.src.user.dto.request.EmailCodeValidationRequest;
 import kr.co.finote.backend.src.user.dto.request.EmailJoinRequest;
 import kr.co.finote.backend.src.user.dto.response.EmailCodeValidationResponse;
+import kr.co.finote.backend.src.user.dto.response.ValidationBlogNameResponse;
+import kr.co.finote.backend.src.user.dto.response.ValidationNicknameResponse;
 import kr.co.finote.backend.src.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,22 +33,20 @@ public class UserService {
     private final MailService mailService;
     private final EmailCodeCacheService emailCodeCacheService;
 
-    public void validateNickname(String nickname) {
+    public ValidationNicknameResponse validateNickname(String nickname) {
         boolean existsByNickname = userRepository.existsByNicknameAndIsDeleted(nickname, false);
         if (existsByNickname) {
-            throw new InvalidInputException(ResponseCode.DUPLICATE_NICKNAME);
-        } else if (nickname.length() > NICK_NAME_MAX_LENGTH) {
-            throw new InvalidInputException(ResponseCode.NICKNAME_TOO_LONG);
-        } // 그 외 금지문자 포함 등의 error 처리 예정
+            return ValidationNicknameResponse.createValidationNicknameRResponse(true);
+        }
+        return ValidationNicknameResponse.createValidationNicknameRResponse(false);
     }
 
-    public void validateBlogName(String blogName) {
+    public ValidationBlogNameResponse validateBlogName(String blogName) {
         boolean existsByBlogName = userRepository.existsByBlogNameAndIsDeleted(blogName, false);
         if (existsByBlogName) {
-            throw new InvalidInputException(ResponseCode.DUPLICATE_BLOG_NAME);
-        } else if (blogName.length() > BLOG_NAME_MAX_LENGTH) {
-            throw new InvalidInputException(ResponseCode.BLOG_NAME_TOO_LONG);
+            return ValidationBlogNameResponse.createValidationBlogNameRResponse(true);
         } // 그 외 금지문자 포함 등의 error 처리 예정
+        return ValidationBlogNameResponse.createValidationBlogNameRResponse(false);
     }
 
     @Transactional


### PR DESCRIPTION
### ✍🏻 개요
중복 검사 API에서 중복일 때 에러를 던지는 것이 아닌, duplicate 여부를 true, false로 내리도록 변경합니다

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- nickname, blogname validation API 응답 형식 수정

<br>

### 👥 To Reviewers

