### PR TITLE
[FIN-316] feat: 글의 총 좋아요 수 API

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
+++ b/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
@@ -121,7 +121,8 @@ public class ArticleApi {
 
     @Operation(summary = "글의 총 좋아요 수")
     @GetMapping("/total-like/{nickname}/{title}")
-    public ArticleTotalLikeResponse totalLike(@PathVariable String nickname, @PathVariable String title) {
+    public ArticleTotalLikeResponse totalLike(
+            @PathVariable String nickname, @PathVariable String title) {
         return articleService.totalLike(nickname, title);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
+++ b/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
@@ -103,6 +103,7 @@ public class ArticleApi {
         return articleService.articlesAll(nickname, page, size);
     }
 
+    /* 글 좋아요 관련 API */
     @Operation(summary = "닉네임/제목 기반 유저의 블로그 글 좋아요", description = "이미 좋아요 되어있다면 좋아요 수 증가하지 않음")
     @PostMapping("/like/{nickname}/{title}")
     public LikeResponse postLikeByNicknameAndTitle(
@@ -116,5 +117,11 @@ public class ArticleApi {
     public ArticleLikeCheckResponse checkLike(
             @LoginOptional User user, @PathVariable String nickname, @PathVariable String title) {
         return articleService.checkLike(user, nickname, title);
+    }
+
+    @Operation(summary = "글의 총 좋아요 수")
+    @GetMapping("/total-like/{nickname}/{title}")
+    public ArticleTotalLikeResponse totalLike(@PathVariable String nickname, @PathVariable String title) {
+        return articleService.totalLike(nickname, title);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/dto/response/ArticleTotalLikeResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/article/dto/response/ArticleTotalLikeResponse.java
@@ -10,8 +10,6 @@ public class ArticleTotalLikeResponse {
     private int totalLike;
 
     public static ArticleTotalLikeResponse createArticleTotalLikeResponse(int totalLike) {
-        return ArticleTotalLikeResponse.builder()
-                .totalLike(totalLike)
-                .build();
+        return ArticleTotalLikeResponse.builder().totalLike(totalLike).build();
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/dto/response/ArticleTotalLikeResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/article/dto/response/ArticleTotalLikeResponse.java
@@ -1,0 +1,17 @@
+package kr.co.finote.backend.src.article.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ArticleTotalLikeResponse {
+
+    private int totalLike;
+
+    public static ArticleTotalLikeResponse createArticleTotalLikeResponse(int totalLike) {
+        return ArticleTotalLikeResponse.builder()
+                .totalLike(totalLike)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -271,4 +271,9 @@ public class ArticleService {
 
         return ArticleLikeCheckResponse.createArticleLikeCheckResponse(isLiked);
     }
+
+    public ArticleTotalLikeResponse totalLike(String authorNickname, String title) {
+        Article article = findByNicknameAndTitle(authorNickname, title);
+        return ArticleTotalLikeResponse.createArticleTotalLikeResponse(article.getTotalLike());
+    }
 }


### PR DESCRIPTION
### ✍🏻 개요
프론트엔드에서 글 조회시 SSR을 사용하고 있지만, 좋아요 컴포넌트의 경우 유저 식별이 필요한 로직이 필요합니다.
따라서, 글의 총 좋아요 수를 확인하는 API를 별도로 분리하여 클라이언트 사이드에서 호출할 수 있도록 합니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
글 좋아요 수를 반환하는 API가 추가되었습니다.

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
