### PR TITLE
hotfix: 글 제목에 불필요한 공백이 있는 경우 trim 처리

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/document/ArticleDocument.java
+++ b/src/main/java/kr/co/finote/backend/src/article/document/ArticleDocument.java
@@ -39,7 +39,7 @@ public class ArticleDocument {
     public static ArticleDocument createDocument(Long articleId, ArticleRequest request, User user) {
         return ArticleDocument.builder()
                 .articleId(articleId)
-                .title(request.getTitle())
+                .title(request.getTitle().trim())
                 .body(request.getBody())
                 .totalLike(0)
                 .reply(0)

--- a/src/main/java/kr/co/finote/backend/src/article/domain/Article.java
+++ b/src/main/java/kr/co/finote/backend/src/article/domain/Article.java
@@ -48,7 +48,7 @@ public class Article extends BaseEntity {
             // 로고
         }
         return Article.builder()
-                .title(articleRequest.getTitle())
+                .title(articleRequest.getTitle().trim())
                 .body(articleRequest.getBody())
                 .thumbnail(thumbnail1)
                 .user(user)
@@ -61,7 +61,7 @@ public class Article extends BaseEntity {
     }
 
     public void editArticle(ArticleRequest articleRequest) {
-        this.title = articleRequest.getTitle();
+        this.title = articleRequest.getTitle().trim();
         this.body = articleRequest.getBody();
     }
 


### PR DESCRIPTION
### ✍🏻 개요
글 조회 시, 제목 양 끝에 불필요한 공백이 있는 경우 정상적으로 글 조회가 되지 않는 경우가 있었습니다.
이를 위해, 불필요한 공백 제거 로직을 추가하여 글 제목을 저장합니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 글 저장, 수정, es에 저장 시 글 제목에 trim 처리 추가

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
