### PR TITLE
[FIN-323] feat: 질문글 생성 API

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
+++ b/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
@@ -43,7 +43,10 @@ public enum ResponseCode {
     /* follow error */
     ALREADY_FOLLOWING(BAD_REQUEST, "400_ARLEADY_FOLLWING", "이미 팔로잉 한 유저입니다."),
     NOT_FOLLOWING(BAD_REQUEST, "400_NOT_FOLLOWING", "팔로우하지 않은 유저입니다."),
-    SELF_FOLLOWING(BAD_REQUEST, "400_SELF_FOLLOWIG", "자기 자신을 팔로우/언팔로우 할 수 없습니다.");
+    SELF_FOLLOWING(BAD_REQUEST, "400_SELF_FOLLOWIG", "자기 자신을 팔로우/언팔로우 할 수 없습니다."),
+
+    /* question error */
+    QUESTION_ALREADY_EXIST(BAD_REQUEST, "400_QUESTION_ALREADY_EXIST", "같은 제목의 질문 글을 이미 등록했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kr/co/finote/backend/src/article/domain/Article.java
+++ b/src/main/java/kr/co/finote/backend/src/article/domain/Article.java
@@ -23,12 +23,10 @@ public class Article extends BaseEntity {
     private User user;
 
     @Column(nullable = false)
-    @ColumnDefault("")
-    private String title;
+    private String title = "";
 
     @Column(columnDefinition = "TEXT", nullable = false)
-    @ColumnDefault("")
-    private String body;
+    private String body = "";
 
     @ColumnDefault("0")
     private int totalLike;
@@ -36,9 +34,8 @@ public class Article extends BaseEntity {
     @ColumnDefault("0")
     private int totalReply;
 
-    @ColumnDefault("")
     @Column(nullable = false)
-    private String thumbnail;
+    private String thumbnail = "";
 
     public static Article createArticle(ArticleRequest articleRequest, User user) {
         String thumbnail1 = articleRequest.getThumbnail();

--- a/src/main/java/kr/co/finote/backend/src/article/domain/Keyword.java
+++ b/src/main/java/kr/co/finote/backend/src/article/domain/Keyword.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -20,8 +19,7 @@ public class Keyword extends BaseEntity {
     @Column(name = "id", nullable = false)
     private Long id;
 
-    @ColumnDefault("")
-    private String value;
+    private String value = "";
 
     public static Keyword createKeyword(String keyword) {
         return Keyword.builder().value(keyword).build();

--- a/src/main/java/kr/co/finote/backend/src/qna/api/QuestionApi.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/api/QuestionApi.java
@@ -1,0 +1,34 @@
+package kr.co.finote.backend.src.qna.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
+import kr.co.finote.backend.global.annotation.Login;
+import kr.co.finote.backend.src.qna.dto.request.PostQuestionRequest;
+import kr.co.finote.backend.src.qna.dto.response.PostQuestionResponse;
+import kr.co.finote.backend.src.qna.service.QuestionService;
+import kr.co.finote.backend.src.user.domain.User;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/qna")
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@Tag(name = "Question API", description = "질문 API")
+public class QuestionApi {
+
+    QuestionService questionService;
+
+    @Operation(summary = "질문글 생성")
+    @PostMapping("/write")
+    public PostQuestionResponse postQuestion(
+            @Login User LoginUser, @RequestBody @Valid PostQuestionRequest request) {
+        return questionService.postQuestion(LoginUser, request);
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/qna/domain/Question.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/domain/Question.java
@@ -26,11 +26,9 @@ public class Question extends BaseEntity {
     private User user;
 
     @Column(nullable = false)
-    @ColumnDefault("")
-    private String title;
+    private String title = "";
 
-    @ColumnDefault("")
-    private String body;
+    private String body = "";
 
     @ColumnDefault("0")
     private int totalLike;

--- a/src/main/java/kr/co/finote/backend/src/qna/domain/Question.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/domain/Question.java
@@ -1,0 +1,50 @@
+package kr.co.finote.backend.src.qna.domain;
+
+import javax.persistence.*;
+import kr.co.finote.backend.global.entity.BaseEntity;
+import kr.co.finote.backend.src.qna.dto.request.PostQuestionRequest;
+import kr.co.finote.backend.src.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Question extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    @ColumnDefault("")
+    private String title;
+
+    @ColumnDefault("")
+    private String body;
+
+    @ColumnDefault("0")
+    private int totalLike;
+
+    @ColumnDefault("0")
+    private int totalAnswer;
+
+    public static Question createQuestion(User user, PostQuestionRequest request) {
+        return Question.builder()
+                .user(user)
+                .title(request.getTitle())
+                .body(request.getBody())
+                .totalLike(0)
+                .totalAnswer(0)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/qna/dto/request/PostQuestionRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/dto/request/PostQuestionRequest.java
@@ -1,0 +1,20 @@
+package kr.co.finote.backend.src.qna.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostQuestionRequest {
+
+    @NotBlank(message = "제목을 입력해주세요")
+    private String title;
+
+    @NotBlank(message = "내용을 입력해주세요")
+    private String body;
+}

--- a/src/main/java/kr/co/finote/backend/src/qna/dto/response/PostQuestionResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/dto/response/PostQuestionResponse.java
@@ -1,0 +1,27 @@
+package kr.co.finote.backend.src.qna.dto.response;
+
+import kr.co.finote.backend.src.qna.domain.Question;
+import kr.co.finote.backend.src.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostQuestionResponse {
+
+    private Long id;
+    private String nickname;
+    private String title;
+
+    public static PostQuestionResponse of(User user, Question question) {
+        return PostQuestionResponse.builder()
+                .id(question.getId())
+                .nickname(user.getNickname())
+                .title(question.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/qna/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/repository/QuestionRepository.java
@@ -1,0 +1,11 @@
+package kr.co.finote.backend.src.qna.repository;
+
+import java.util.Optional;
+import kr.co.finote.backend.src.qna.domain.Question;
+import kr.co.finote.backend.src.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    Optional<Question> findByUserAndTitleAndIsDeleted(User user, String title, boolean isDeleted);
+}

--- a/src/main/java/kr/co/finote/backend/src/qna/service/QuestionService.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/service/QuestionService.java
@@ -1,0 +1,36 @@
+package kr.co.finote.backend.src.qna.service;
+
+import kr.co.finote.backend.global.code.ResponseCode;
+import kr.co.finote.backend.global.exception.InvalidInputException;
+import kr.co.finote.backend.src.qna.domain.Question;
+import kr.co.finote.backend.src.qna.dto.request.PostQuestionRequest;
+import kr.co.finote.backend.src.qna.dto.response.PostQuestionResponse;
+import kr.co.finote.backend.src.qna.repository.QuestionRepository;
+import kr.co.finote.backend.src.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+
+    @Transactional
+    public PostQuestionResponse postQuestion(User author, PostQuestionRequest request) {
+        isDuplicatedTitle(author, request);
+
+        Question savedQuestion = questionRepository.save(Question.createQuestion(author, request));
+        return PostQuestionResponse.of(author, savedQuestion);
+    }
+
+    private void isDuplicatedTitle(User author, PostQuestionRequest request) {
+        questionRepository
+                .findByUserAndTitleAndIsDeleted(author, request.getTitle(), false)
+                .ifPresent(
+                        question -> {
+                            throw new InvalidInputException(ResponseCode.QUESTION_ALREADY_EXIST);
+                        });
+    }
+}


### PR DESCRIPTION
### ✍🏻 개요
Q&A 커뮤니티 기능을 구현하기 위해, 기본적인 도메인 필수 클래스들을 생성하였고, 질문 글 생성 API를 구현했습니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- ERD설계에 맞추어 Question entity 설계
- qna 도메인 패키지 추가
- 질문글 생성 API 구현

<br>

### 👥 To Reviewers
프론트엔드 협의 하에 향후 질문 글 또한 닉네임/제목으로 조회하기 때문에 이와 관련한 중복 검증 로직을 사용하였습니다.
