### PR TITLE
[FIN-324] feat: 질문글 조회 API

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
+++ b/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
@@ -46,7 +46,8 @@ public enum ResponseCode {
     SELF_FOLLOWING(BAD_REQUEST, "400_SELF_FOLLOWIG", "자기 자신을 팔로우/언팔로우 할 수 없습니다."),
 
     /* question error */
-    QUESTION_ALREADY_EXIST(BAD_REQUEST, "400_QUESTION_ALREADY_EXIST", "같은 제목의 질문 글을 이미 등록했습니다.");
+    QUESTION_ALREADY_EXIST(BAD_REQUEST, "400_QUESTION_ALREADY_EXIST", "같은 제목의 질문 글을 이미 등록했습니다."),
+    QUESTION_NOT_FOUND(NOT_FOUND, "404_QUESTION_NOT_FOUND", "해당 질문 글을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
+++ b/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
@@ -37,6 +37,9 @@ public class SecurityConfig {
     @Value("${COMMON_URLS}")
     private String[] commonUrls;
 
+    @Value("${QNA_URLS}")
+    private String[] qnaUrls;
+
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtService jwtService;
 
@@ -60,6 +63,8 @@ public class SecurityConfig {
                 .antMatchers(articleUrls)
                 .authenticated()
                 .antMatchers(commonUrls)
+                .authenticated()
+                .antMatchers(qnaUrls)
                 .authenticated()
                 .anyRequest()
                 .permitAll()

--- a/src/main/java/kr/co/finote/backend/src/qna/api/QuestionApi.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/api/QuestionApi.java
@@ -6,15 +6,13 @@ import javax.validation.Valid;
 import kr.co.finote.backend.global.annotation.Login;
 import kr.co.finote.backend.src.qna.dto.request.PostQuestionRequest;
 import kr.co.finote.backend.src.qna.dto.response.PostQuestionResponse;
+import kr.co.finote.backend.src.qna.dto.response.QuestionResponse;
 import kr.co.finote.backend.src.qna.service.QuestionService;
 import kr.co.finote.backend.src.user.domain.User;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/qna")
@@ -30,5 +28,12 @@ public class QuestionApi {
     public PostQuestionResponse postQuestion(
             @Login User LoginUser, @RequestBody @Valid PostQuestionRequest request) {
         return questionService.postQuestion(LoginUser, request);
+    }
+
+    @Operation(summary = "질문글 조회")
+    @GetMapping("/{nickname}/{title}")
+    public QuestionResponse getQuestionByNicknameAndTitle(
+            @PathVariable String nickname, @PathVariable String title) {
+        return questionService.lookupByNicknameAndTitle(nickname, title);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/qna/dto/response/QuestionResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/dto/response/QuestionResponse.java
@@ -1,0 +1,37 @@
+package kr.co.finote.backend.src.qna.dto.response;
+
+import java.time.format.DateTimeFormatter;
+import kr.co.finote.backend.src.qna.domain.Question;
+import kr.co.finote.backend.src.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuestionResponse {
+
+    private Long id;
+
+    private int totalAnswer;
+
+    private String title;
+    private String body;
+    private String authorNickname;
+    private String profileImageUrl;
+    private String createdDate;
+
+    public static QuestionResponse of(User user, Question question) {
+        return QuestionResponse.builder()
+                .id(question.getId())
+                .totalAnswer(question.getTotalAnswer())
+                .title(question.getTitle())
+                .authorNickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .createdDate(question.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/qna/service/QuestionService.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/service/QuestionService.java
@@ -2,11 +2,14 @@ package kr.co.finote.backend.src.qna.service;
 
 import kr.co.finote.backend.global.code.ResponseCode;
 import kr.co.finote.backend.global.exception.InvalidInputException;
+import kr.co.finote.backend.global.exception.NotFoundException;
 import kr.co.finote.backend.src.qna.domain.Question;
 import kr.co.finote.backend.src.qna.dto.request.PostQuestionRequest;
 import kr.co.finote.backend.src.qna.dto.response.PostQuestionResponse;
+import kr.co.finote.backend.src.qna.dto.response.QuestionResponse;
 import kr.co.finote.backend.src.qna.repository.QuestionRepository;
 import kr.co.finote.backend.src.user.domain.User;
+import kr.co.finote.backend.src.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,12 +20,27 @@ public class QuestionService {
 
     private final QuestionRepository questionRepository;
 
+    private final UserService userService;
+
     @Transactional
     public PostQuestionResponse postQuestion(User author, PostQuestionRequest request) {
         isDuplicatedTitle(author, request);
 
         Question savedQuestion = questionRepository.save(Question.createQuestion(author, request));
         return PostQuestionResponse.of(author, savedQuestion);
+    }
+
+    public QuestionResponse lookupByNicknameAndTitle(String nickname, String title) {
+        User author = userService.findByNickname(nickname);
+        Question findQuestion = findByUserAndTitle(author, title);
+
+        return QuestionResponse.of(author, findQuestion);
+    }
+
+    private Question findByUserAndTitle(User user, String title) {
+        return questionRepository
+                .findByUserAndTitleAndIsDeleted(user, title, false)
+                .orElseThrow(() -> new NotFoundException(ResponseCode.QUESTION_NOT_FOUND));
     }
 
     private void isDuplicatedTitle(User author, PostQuestionRequest request) {


### PR DESCRIPTION
### ✍🏻 개요
질문 글을 질문 작성자의 닉네임과 제목으로 조회할 수 있는 API를 구현하였고, 닉네임/제목으로 조회하는 이유는 글 조회 API 수정하였던 
것과 동일합니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 닉네임/제목 기반 질문글 조회 API 구현
- 질문 글 작성 엔드포인트가 Security 인증을 받도록 설정

<br>

### 👥 To Reviewers
글 조회와 달리 약간 로직 흐름이 바뀐 부분이 있는데 이는 코멘트 달아 두겠습니다!
