### PR TITLE
[FIN-326] feat: 질문글 삭제 API

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
+++ b/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
@@ -48,7 +48,7 @@ public enum ResponseCode {
     /** question error */
     QUESTION_ALREADY_EXIST(BAD_REQUEST, "400_QUESTION_ALREADY_EXIST", "같은 제목의 질문 글을 이미 등록했습니다."),
     QUESTION_NOT_FOUND(NOT_FOUND, "404_QUESTION_NOT_FOUND", "해당 질문 글을 찾을 수 없습니다."),
-    QUESTION_NOT_WRITER(BAD_REQUEST, "404_QUESTION_NOT_WRITER", "질문 글 수정 권한이 없습니다.");
+    QUESTION_NOT_WRITER(BAD_REQUEST, "404_QUESTION_NOT_WRITER", "질문 글 수정/삭제 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kr/co/finote/backend/src/qna/api/QuestionApi.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/api/QuestionApi.java
@@ -51,4 +51,10 @@ public class QuestionApi {
             @RequestBody @Valid PostQuestionRequest request) {
         return questionService.editQuestion(loginUser, questionId, request);
     }
+
+    @Operation(summary = "질문글 삭제")
+    @PostMapping("/delete/{question-id}")
+    public void deleteQuestion(@Login User loginUser, @PathVariable("question-id") Long questionId) {
+        questionService.deleteQuestion(loginUser, questionId);
+    }
 }

--- a/src/main/java/kr/co/finote/backend/src/qna/domain/Question.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/domain/Question.java
@@ -50,4 +50,8 @@ public class Question extends BaseEntity {
         this.title = request.getTitle().trim();
         this.body = request.getBody();
     }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/kr/co/finote/backend/src/qna/service/QuestionService.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/service/QuestionService.java
@@ -63,6 +63,20 @@ public class QuestionService {
         return PostQuestionResponse.of(loginUser, question);
     }
 
+    @Transactional
+    public void deleteQuestion(User loginUser, Long questionId) {
+        Question question =
+                questionRepository
+                        .findByIdAndIsDeleted(questionId, false)
+                        .orElseThrow(() -> new NotFoundException(ResponseCode.QUESTION_NOT_FOUND));
+
+        if (!question.getUser().getNickname().equals(loginUser.getNickname())) {
+            throw new InvalidInputException(ResponseCode.QUESTION_NOT_WRITER);
+        }
+
+        question.delete();
+    }
+
     private Question findByUserAndTitle(User user, String title) {
         return questionRepository
                 .findByUserAndTitleAndIsDeleted(user, title, false)


### PR DESCRIPTION
### ✍🏻 개요
질문 글 삭제 API입니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- id 기반 질문글 삭제 API 구현

<br>

### 👥 To Reviewers
블로그 글과 달리, 질문글 좋아요 기록 엔티티가 아직 없어서 삭제 시 같이 삭제해야할 사항은 없습니다.
