### PR TITLE
[FIN-332] feat: 조회수 로직 구현

### DIFF
--- a/src/main/java/kr/co/finote/backend/BackendApplication.java
+++ b/src/main/java/kr/co/finote/backend/BackendApplication.java
@@ -1,6 +1,8 @@
 package kr.co.finote.backend;
 
 import java.time.LocalDateTime;
+import java.util.TimeZone;
+import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -14,6 +16,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @Slf4j
 public class BackendApplication {
+
+    @PostConstruct
+    public void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(BackendApplication.class, args);

--- a/src/main/java/kr/co/finote/backend/global/config/RedisConfig.java
+++ b/src/main/java/kr/co/finote/backend/global/config/RedisConfig.java
@@ -29,9 +29,7 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-
         return redisTemplate;
     }
 }

--- a/src/main/java/kr/co/finote/backend/global/entity/BaseEntity.java
+++ b/src/main/java/kr/co/finote/backend/global/entity/BaseEntity.java
@@ -19,4 +19,9 @@ public class BaseEntity {
     @LastModifiedDate private LocalDateTime lastModifiedDate;
 
     protected Boolean isDeleted = false;
+
+    public BaseEntity() {
+        this.createdDate = LocalDateTime.now();
+        this.lastModifiedDate = LocalDateTime.now();
+    }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
+++ b/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import kr.co.finote.backend.global.annotation.Login;
 import kr.co.finote.backend.global.annotation.LoginOptional;
@@ -44,14 +45,14 @@ public class ArticleApi {
     @Operation(summary = "블로그 id로 글 조회")
     @GetMapping("/{articleId}")
     public ArticleResponse getArticle(@LoginOptional User user, @PathVariable Long articleId) {
-        return articleService.lookupById(user, articleId);
+        return articleService.findById(articleId);
     }
 
     @Operation(summary = "블로그 작성자 닉네임, 글 제목으로 조회")
     @GetMapping("/{nickname}/{title}")
     public ArticleResponse getArticleByNicknameAndTitle(
-            @PathVariable String nickname, @PathVariable String title) {
-        return articleService.lookupByNicknameAndTitle(nickname, title);
+            @PathVariable String nickname, @PathVariable String title, HttpServletRequest request) {
+        return articleService.lookupByNicknameAndTitle(nickname, title, request);
     }
 
     @Operation(summary = "블로그 글 수정")

--- a/src/main/java/kr/co/finote/backend/src/article/domain/Article.java
+++ b/src/main/java/kr/co/finote/backend/src/article/domain/Article.java
@@ -11,7 +11,6 @@ import org.hibernate.annotations.ColumnDefault;
 @Getter
 @Builder
 @NoArgsConstructor
-@AllArgsConstructor
 public class Article extends BaseEntity {
 
     @Id
@@ -39,6 +38,26 @@ public class Article extends BaseEntity {
 
     @Column(nullable = false, length = 500)
     private String thumbnail = "";
+
+    public Article(
+            Long id,
+            User user,
+            String title,
+            String body,
+            int totalLike,
+            int totalReply,
+            int totalView,
+            String thumbnail) {
+        super();
+        this.id = id;
+        this.user = user;
+        this.title = title;
+        this.body = body;
+        this.totalLike = totalLike;
+        this.totalReply = totalReply;
+        this.totalView = totalView;
+        this.thumbnail = thumbnail;
+    }
 
     public static Article createArticle(ArticleRequest articleRequest, User user) {
         String thumbnail1 = articleRequest.getThumbnail();

--- a/src/main/java/kr/co/finote/backend/src/article/domain/Article.java
+++ b/src/main/java/kr/co/finote/backend/src/article/domain/Article.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.ColumnDefault;
 @Getter
 @Builder
 @NoArgsConstructor
+@SuppressWarnings("PMD.UnusedAssignment")
 public class Article extends BaseEntity {
 
     @Id

--- a/src/main/java/kr/co/finote/backend/src/article/domain/Article.java
+++ b/src/main/java/kr/co/finote/backend/src/article/domain/Article.java
@@ -34,6 +34,9 @@ public class Article extends BaseEntity {
     @ColumnDefault("0")
     private int totalReply;
 
+    @ColumnDefault("0")
+    private int totalView;
+
     @Column(nullable = false, length = 500)
     private String thumbnail = "";
 
@@ -65,5 +68,9 @@ public class Article extends BaseEntity {
 
     public void deleteArticle() {
         this.isDeleted = true;
+    }
+
+    public void updateTotalView() {
+        this.totalView++;
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -96,7 +96,6 @@ public class ArticleService {
         return ArticleResponse.of(article);
     }
 
-    @Transactional
     public void updateViewOrNot(HttpServletRequest request, Article article) {
         String ipAddress = request.getHeader("X-FORWARDED-FOR"); // 로드밸런서를 통해 들들어올 경우 IP 변경
         if (ipAddress == null) {

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleViewCacheService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleViewCacheService.java
@@ -1,0 +1,28 @@
+package kr.co.finote.backend.src.article.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.joda.time.LocalDateTime;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ArticleViewCacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public boolean hasViewCache(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    public void cacheView(String key) {
+        redisTemplate.opsForValue().set(key, true);
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime midnight =
+                now.toLocalDate().toDateTimeAtStartOfDay().plusDays(1).toLocalDateTime();
+        long validTime = midnight.toDateTime().getMillis() - now.toDateTime().getMillis();
+        redisTemplate.expire(key, validTime, java.util.concurrent.TimeUnit.MILLISECONDS);
+    }
+}

--- a/src/test/java/kr/co/finote/backend/src/article/service/ArticleServiceTest.java
+++ b/src/test/java/kr/co/finote/backend/src/article/service/ArticleServiceTest.java
@@ -6,9 +6,11 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Optional;
 import kr.co.finote.backend.global.exception.InvalidInputException;
+import kr.co.finote.backend.global.exception.NotFoundException;
 import kr.co.finote.backend.src.article.document.ArticleDocument;
 import kr.co.finote.backend.src.article.domain.Article;
 import kr.co.finote.backend.src.article.dto.request.ArticleRequest;
+import kr.co.finote.backend.src.article.dto.response.ArticleResponse;
 import kr.co.finote.backend.src.article.dto.response.PostArticleResponse;
 import kr.co.finote.backend.src.article.repository.ArticleEsRepository;
 import kr.co.finote.backend.src.article.repository.ArticleRepository;
@@ -49,7 +51,7 @@ class ArticleServiceTest {
         when(articleRepository.findByUserAndTitleAndIsDeleted(user, TITLE, false))
                 .thenReturn(Optional.empty());
         when(articleRepository.save(ArgumentMatchers.any(Article.class)))
-                .thenReturn(new Article(1L, user, TITLE, BODY, 0, 0, ""));
+                .thenReturn(new Article(1L, user, TITLE, BODY, 0, 0, 0, ""));
         when(articleEsRepository.save(ArgumentMatchers.any()))
                 .thenReturn(new ArticleDocument("id", 1L, TITLE, BODY, 0, 0, "author", "2023-01-01", ""));
 
@@ -74,5 +76,77 @@ class ArticleServiceTest {
         assertThrows(InvalidInputException.class, () -> articleService.save(articleRequest, user));
 
         // then
+    }
+
+    @Test
+    @DisplayName("findById Success")
+    void findByIdSuccess() {
+        // given
+        Article article = new Article(1L, new User(), TITLE, BODY, 0, 0, 0, "");
+        when(articleRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(article));
+
+        // when
+        ArticleResponse articleResponse = articleService.findById(1L);
+
+        // then
+        Assertions.assertThat(articleResponse.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("findById Fail - 존재하지 않는 게시글")
+    void findByIdFail() {
+        // given
+        when(articleRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.empty());
+
+        // when
+        assertThrows(NotFoundException.class, () -> articleService.findById(1L));
+
+        // then
+    }
+
+    @Test
+    @DisplayName("findByNicknameTitle Success")
+    void findByNicknameAndTitleSuccess() {
+        // given
+        User user = new User();
+        Article article = new Article(1L, new User(), TITLE, BODY, 0, 0, 0, "");
+        when(articleRepository.findByUserAndTitleAndIsDeleted(user, TITLE, false))
+                .thenReturn(Optional.of(article));
+        when(userService.findByNickname("nickname")).thenReturn(user);
+
+        // when
+        Article findArticle = articleService.findByNicknameAndTitle("nickname", TITLE);
+
+        // then
+        Assertions.assertThat(findArticle.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("findByNicknameTitle Fail")
+    void findByNicknameAndTitleFail() {
+        // given
+        User user = new User();
+        Article article = new Article(1L, new User(), TITLE, BODY, 0, 0, 0, "");
+        when(articleRepository.findByUserAndTitleAndIsDeleted(user, TITLE, false))
+                .thenReturn(Optional.empty());
+        when(userService.findByNickname("nickname")).thenReturn(user);
+
+        // when
+        assertThrows(
+                NotFoundException.class, () -> articleService.findByNicknameAndTitle("nickname", TITLE));
+
+        // then
+    }
+
+    @Test
+    @DisplayName("lookUpByNicknameAndTitle Test")
+    void lookupByNicknameAndTitle() {
+        // given
+        Article article = new Article(1L, new User(), TITLE, BODY, 0, 0, 0, "");
+
+        // when
+
+        // then
+
     }
 }

--- a/src/test/java/kr/co/finote/backend/src/article/service/ArticleServiceTest.java
+++ b/src/test/java/kr/co/finote/backend/src/article/service/ArticleServiceTest.java
@@ -38,8 +38,8 @@ class ArticleServiceTest {
 
     private static final String TITLE = "title";
     private static final String BODY = "body";
-
     private static final String THUMBNAIL = "thumbnail";
+    private static final String NICKNAME = "nickname";
 
     @Test
     @DisplayName("게시글 작성 성공")
@@ -112,10 +112,10 @@ class ArticleServiceTest {
         Article article = new Article(1L, new User(), TITLE, BODY, 0, 0, 0, "");
         when(articleRepository.findByUserAndTitleAndIsDeleted(user, TITLE, false))
                 .thenReturn(Optional.of(article));
-        when(userService.findByNickname("nickname")).thenReturn(user);
+        when(userService.findByNickname(NICKNAME)).thenReturn(user);
 
         // when
-        Article findArticle = articleService.findByNicknameAndTitle("nickname", TITLE);
+        Article findArticle = articleService.findByNicknameAndTitle(NICKNAME, TITLE);
 
         // then
         Assertions.assertThat(findArticle.getId()).isEqualTo(1L);
@@ -126,27 +126,14 @@ class ArticleServiceTest {
     void findByNicknameAndTitleFail() {
         // given
         User user = new User();
-        Article article = new Article(1L, new User(), TITLE, BODY, 0, 0, 0, "");
         when(articleRepository.findByUserAndTitleAndIsDeleted(user, TITLE, false))
                 .thenReturn(Optional.empty());
-        when(userService.findByNickname("nickname")).thenReturn(user);
+        when(userService.findByNickname(NICKNAME)).thenReturn(user);
 
         // when
         assertThrows(
-                NotFoundException.class, () -> articleService.findByNicknameAndTitle("nickname", TITLE));
+                NotFoundException.class, () -> articleService.findByNicknameAndTitle(NICKNAME, TITLE));
 
         // then
-    }
-
-    @Test
-    @DisplayName("lookUpByNicknameAndTitle Test")
-    void lookupByNicknameAndTitle() {
-        // given
-        Article article = new Article(1L, new User(), TITLE, BODY, 0, 0, 0, "");
-
-        // when
-
-        // then
-
     }
 }


### PR DESCRIPTION
### ✍🏻 개요
중복 조회수를 방지하고 IP당 글에 대해 하루 한 번만 조회수를 반영합니다

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 조회수는 IP-글 당 하루에 하나 증가
- IP의 글 조회 이력을 하루동안 저장하기 위해 redis 활용

<br>

### 👥 To Reviewers

