### PR TITLE
hotfix: add no args constructor to request dto

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/dto/request/ArticleRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/article/dto/request/ArticleRequest.java
@@ -4,9 +4,11 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class ArticleRequest {
 
     @NotBlank(message = "제목을 입력해주세요.")

--- a/src/main/java/kr/co/finote/backend/src/user/dto/request/AdditionalInfoRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/request/AdditionalInfoRequest.java
@@ -3,9 +3,11 @@ package kr.co.finote.backend.src.user.dto.request;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class AdditionalInfoRequest {
 
     // TODO : finote의 기본 프사 S3링크를 @Default로 설정하기

--- a/src/main/java/kr/co/finote/backend/src/user/dto/request/EmailCodeRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/request/EmailCodeRequest.java
@@ -4,9 +4,11 @@ import javax.validation.constraints.NotNull;
 import kr.co.finote.backend.global.annotation.ValidEmail;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class EmailCodeRequest {
 
     @NotNull(message = "이메일이 입력되지 않았습니다.")

--- a/src/main/java/kr/co/finote/backend/src/user/dto/request/EmailCodeValidationRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/request/EmailCodeValidationRequest.java
@@ -2,9 +2,11 @@ package kr.co.finote.backend.src.user.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class EmailCodeValidationRequest {
 
     private String email;

--- a/src/main/java/kr/co/finote/backend/src/user/dto/request/EmailJoinRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/request/EmailJoinRequest.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@NotBlank
 public class EmailJoinRequest {
 
     @NotBlank(message = "이메일이 입력되지 않았습니다.")

--- a/src/main/java/kr/co/finote/backend/src/user/service/JwtService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/JwtService.java
@@ -36,6 +36,9 @@ public class JwtService {
             String token = jwtTokenProvider.createToken(user.getEmail());
             String newRefreshToken = jwtTokenProvider.createRefreshToken();
 
+            log.info("new access token = {}", token);
+            log.info("new refresh token = {}", newRefreshToken);
+
             user.updateRefreshToken(newRefreshToken);
 
             return new JwtToken(token, newRefreshToken);


### PR DESCRIPTION
### ✍🏻 개요
requestbody DTO를 바인딩 하는 과정에서 object mapper가 사용되어 기본 생성자가 필요합니다.
테스트를 위해 all args 생성자를 사용함으로써 기본 생성자를 명시적으로 지정해주어야 합니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항

<br>

### 👥 To Reviewers

