### PR TITLE
hotfix: add no args constructor to request dto

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/user/dto/request/EmailJoinRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/request/EmailJoinRequest.java
@@ -5,9 +5,11 @@ import kr.co.finote.backend.global.annotation.ValidEmail;
 import kr.co.finote.backend.global.annotation.ValidPassword;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 @NotBlank
 public class EmailJoinRequest {
 


### PR DESCRIPTION
### ✍🏻 개요
requestbody DTO를 바인딩 하는 과정에서 object mapper가 사용되어 기본 생성자가 필요합니다.
테스트를 위해 all args 생성자를 사용함으로써 기본 생성자를 명시적으로 지정해주어야 합니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항

<br>

### 👥 To Reviewers
