### PR TITLE
hotfix : 해당 게시글을 찾을 수 없습니다 에러 해결 후 코드 복구

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -286,18 +286,9 @@ public class ArticleService {
     public Article findByNicknameAndTitle(String nickname, String title) {
         User findUser = userService.findByNickname(nickname); // 유저가 존재하는지 확인
 
-        // TODO : 에러 해결 후 원래대로 return 으로 article 객체 반환
-        Optional<Article> findArticle =
-                articleRepository.findByUserAndTitleAndIsDeleted(findUser, title, false);
-        if (findArticle.isPresent()) {
-            return findArticle.get();
-        } else {
-            log.error("nickname = {}, title = {}", nickname, findArticle.get().getTitle());
-            throw new NotFoundException(ResponseCode.ARTICLE_NOT_FOUND);
-        }
-        //        return articleRepository
-        //                .findByUserAndTitleAndIsDeleted(findUser, title, false)
-        //                .orElseThrow(() -> new NotFoundException(ResponseCode.ARTICLE_NOT_FOUND));
+        return articleRepository
+                .findByUserAndTitleAndIsDeleted(findUser, title, false)
+                .orElseThrow(() -> new NotFoundException(ResponseCode.ARTICLE_NOT_FOUND));
     }
 
     public ArticleLikeCheckResponse checkLike(User reader, String authorNickname, String title) {

--- a/src/test/java/kr/co/finote/backend/src/article/service/ArticleServiceTest.java
+++ b/src/test/java/kr/co/finote/backend/src/article/service/ArticleServiceTest.java
@@ -136,25 +136,24 @@ class ArticleServiceTest {
         assertThat(findArticle.getId()).isEqualTo(1L);
     }
 
-    //    @Test
-    //    @DisplayName("findByNicknameTitle Fail - 존재하지 않는 게시글")
-    //    void findByNicknameAndTitleFail() {
-    //        // given
-    //        User user = new User();
-    //        when(articleRepository.findByUserAndTitleAndIsDeleted(user, "title", false))
-    //                .thenReturn(Optional.empty());
-    //        when(userService.findByNickname("nickname")).thenReturn(user);
-    //
-    //        // when
-    //        NotFoundException notFoundException =
-    //                assertThrows(
-    //                        NotFoundException.class,
-    //                        () -> articleService.findByNicknameAndTitle("nickname", "title"));
-    //
-    //        // then
-    //
-    // assertThat(notFoundException.getResponseCode()).isEqualTo(ResponseCode.ARTICLE_NOT_FOUND);
-    //    }
+    @Test
+    @DisplayName("findByNicknameTitle Fail - 존재하지 않는 게시글")
+    void findByNicknameAndTitleFail() {
+        // given
+        User user = new User();
+        when(articleRepository.findByUserAndTitleAndIsDeleted(user, "title", false))
+                .thenReturn(Optional.empty());
+        when(userService.findByNickname("nickname")).thenReturn(user);
+
+        // when
+        NotFoundException notFoundException =
+                assertThrows(
+                        NotFoundException.class,
+                        () -> articleService.findByNicknameAndTitle("nickname", "title"));
+
+        // then
+        assertThat(notFoundException.getResponseCode()).isEqualTo(ResponseCode.ARTICLE_NOT_FOUND);
+    }
 
     @Test
     @DisplayName("lookUpByNicknameAndTitle Success")
@@ -181,27 +180,26 @@ class ArticleServiceTest {
         assertThat(articleResponse.getId()).isEqualTo(1L);
     }
 
-    //    @Test
-    //    @DisplayName("lookUpByNicknameAndTitle Fail - 존재하지 않는 게시글")
-    //    void lookupByNicknameAndTitleFail() {
-    //        // given
-    //        User user = new User();
-    //        when(userService.findByNickname("nickname")).thenReturn(user);
-    //        when(articleRepository.findByUserAndTitleAndIsDeleted(user, "title", false))
-    //                .thenReturn(Optional.empty());
-    //        HttpServletRequest request = mock(HttpServletRequest.class);
-    //
-    //        // when
-    //        NotFoundException notFoundException =
-    //                assertThrows(
-    //                        NotFoundException.class,
-    //                        () -> articleService.lookupByNicknameAndTitle("nickname", "title",
-    // request));
-    //
-    //        // then
-    //
-    // assertThat(notFoundException.getResponseCode()).isEqualTo(ResponseCode.ARTICLE_NOT_FOUND);
-    //    }
+    @Test
+    @DisplayName("lookUpByNicknameAndTitle Fail - 존재하지 않는 게시글")
+    void lookupByNicknameAndTitleFail() {
+        // given
+        User user = new User();
+        when(userService.findByNickname("nickname")).thenReturn(user);
+        when(articleRepository.findByUserAndTitleAndIsDeleted(user, "title", false))
+                .thenReturn(Optional.empty());
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        // when
+        NotFoundException notFoundException =
+                assertThrows(
+                        NotFoundException.class,
+                        () -> articleService.lookupByNicknameAndTitle("nickname", "title", request));
+
+        // then
+
+        assertThat(notFoundException.getResponseCode()).isEqualTo(ResponseCode.ARTICLE_NOT_FOUND);
+    }
 
     @Test
     @DisplayName("updateViewOrNot - 조회수 업데이트 O")


### PR DESCRIPTION
### ✍🏻 개요
트렌드 아티클 기능에서 "해당 게시글을 찾을 수 없습니다"에러 발생 해결을 위해 작성했던 로그를 모두 지웠습니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
error 레벨 로그 삭제와 이를 위해 주석처리 됐던 테스트 정상 복구되었습니다.

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
