### PR TITLE
[FIN-360] feat: 질문글 답변 리스트 API

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/qna/api/AnswerApi.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/api/AnswerApi.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import kr.co.finote.backend.global.annotation.Login;
 import kr.co.finote.backend.src.qna.dto.request.PostAnswerRequest;
+import kr.co.finote.backend.src.qna.dto.response.AnswerListResponse;
 import kr.co.finote.backend.src.qna.dto.response.PostAnswerResponse;
 import kr.co.finote.backend.src.qna.service.AnswerService;
 import kr.co.finote.backend.src.user.domain.User;
@@ -30,5 +31,11 @@ public class AnswerApi {
             @PathVariable String title,
             @RequestBody @Valid PostAnswerRequest request) {
         return answerService.postAnswer(loginUser, nickname, title, request);
+    }
+
+    @Operation(summary = "질문 글에 대한 모든 답변 조회")
+    @GetMapping("/answers/{nickname}/{title}")
+    public AnswerListResponse getAnswers(@PathVariable String nickname, @PathVariable String title) {
+        return answerService.getAnswers(nickname, title);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/qna/dto/response/AnswerListResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/dto/response/AnswerListResponse.java
@@ -1,0 +1,20 @@
+package kr.co.finote.backend.src.qna.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AnswerListResponse {
+
+    private List<AnswerResponse> answerResponseList;
+
+    public static AnswerListResponse of(List<AnswerResponse> answerResponseList) {
+        return AnswerListResponse.builder().answerResponseList(answerResponseList).build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/qna/dto/response/AnswerResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/dto/response/AnswerResponse.java
@@ -1,0 +1,35 @@
+package kr.co.finote.backend.src.qna.dto.response;
+
+import java.time.format.DateTimeFormatter;
+import kr.co.finote.backend.src.qna.domain.Answer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AnswerResponse {
+
+    private Long id;
+    private String profileImage;
+    private String nickname;
+    private String createdDate;
+
+    private int totalLike;
+    private int totalUnlike;
+
+    public static AnswerResponse of(Answer answer) {
+        return AnswerResponse.builder()
+                .id(answer.getId())
+                .profileImage(answer.getUser().getProfileImageUrl())
+                .nickname(answer.getUser().getNickname())
+                .createdDate(
+                        answer.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .totalLike(answer.getTotalLike())
+                .totalUnlike(answer.getTotalUnlike())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/qna/repository/AnswerRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/repository/AnswerRepository.java
@@ -1,8 +1,17 @@
 package kr.co.finote.backend.src.qna.repository;
 
+import java.util.List;
 import kr.co.finote.backend.src.qna.domain.Answer;
+import kr.co.finote.backend.src.qna.domain.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AnswerRepository extends JpaRepository<Answer, Long> {}
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+    @Query(
+            "select a from Answer a join fetch a.user where a.question = :question and a.isDeleted = false")
+    List<Answer> findAllWithQuestion(@Param("question") Question question);
+}

--- a/src/main/java/kr/co/finote/backend/src/qna/service/AnswerService.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/service/AnswerService.java
@@ -1,8 +1,12 @@
 package kr.co.finote.backend.src.qna.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import kr.co.finote.backend.src.qna.domain.Answer;
 import kr.co.finote.backend.src.qna.domain.Question;
 import kr.co.finote.backend.src.qna.dto.request.PostAnswerRequest;
+import kr.co.finote.backend.src.qna.dto.response.AnswerListResponse;
+import kr.co.finote.backend.src.qna.dto.response.AnswerResponse;
 import kr.co.finote.backend.src.qna.dto.response.PostAnswerResponse;
 import kr.co.finote.backend.src.qna.repository.AnswerRepository;
 import kr.co.finote.backend.src.user.domain.User;
@@ -23,5 +27,18 @@ public class AnswerService {
 
         Answer savedAnswer = answerRepository.save(answer);
         return PostAnswerResponse.of(savedAnswer);
+    }
+
+    public AnswerListResponse getAnswers(String nickname, String title) {
+        Question question = questionService.findByNicknameAndTitle(nickname, title);
+
+        List<Answer> answers = answerRepository.findAllWithQuestion(question);
+        List<AnswerResponse> answerReponseList = toAnswerReponseList(answers);
+
+        return AnswerListResponse.of(answerReponseList);
+    }
+
+    private List<AnswerResponse> toAnswerReponseList(List<Answer> answerList) {
+        return answerList.stream().map(AnswerResponse::of).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
### ✍🏻 개요
질문글의 달린 모든 답변 글을 리스트로 응답하는 API를 작성하였습니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 글의 모든 댓글과 달리 FetchType.LAZY로 설정해두었습니다.
- fetch join 활용하여 Answer -> AnswerResponse 의 과정에서 지연 로딩으로 인한 N+1문제를 방지하였습니다.

<br>

### 👥 To Reviewers
앞서 올려주신 PR에서 EAGER, LAZY관련해서 제안 드린 부분을 이와 같이 수정하면 좋을 것 같아서 참고용 PR 올려두겠습니다
보시고 의견 주시면 될 것 같습니다!! 우선 이 PR은 승인은 그 전까지 하지말아주세요

