### PR TITLE
[FIN-387] 답변 생성 API 스펙 변경

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/qna/domain/Answer.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/domain/Answer.java
@@ -38,6 +38,6 @@ public class Answer extends BaseEntity {
     private int totalUnlike;
 
     public static Answer createAnswer(User user, Question question, PostAnswerRequest request) {
-        return Answer.builder().user(user).question(question).body(request.getBody()).build();
+        return Answer.builder().user(user).question(question).body(request.getContent()).build();
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/qna/dto/request/PostAnswerRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/dto/request/PostAnswerRequest.java
@@ -13,5 +13,5 @@ import lombok.NoArgsConstructor;
 public class PostAnswerRequest {
 
     @NotBlank(message = "답변 내용을 입력해주세요")
-    private String body;
+    private String content;
 }


### PR DESCRIPTION
### ✍🏻 개요
프론트엔드 쪽에서는 현재 답변, 댓글 UI가 동일하여 공통 컴포넌트로 개발이 진행됩니다.
이에 따라 두 대상의 생성 API 스펙을 동일하게 하는 것으로 협의하여 이에 대응해 답변 생성 API 스펙을 일부 수정합니다.
<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 답변 생성 API의 Request Body에 대한 DTO body 필드를 content 필드로 수정했습니다.

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
