### PR TITLE
hotfix: elasticsearch에 데이터 업데이트하는 api 추가

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
+++ b/src/main/java/kr/co/finote/backend/src/article/api/ArticleApi.java
@@ -127,4 +127,10 @@ public class ArticleApi {
             @PathVariable String nickname, @PathVariable String title) {
         return articleService.totalLike(nickname, title);
     }
+
+    @Operation(summary = "글 데이터 ES 업데이트")
+    @PostMapping("/update-es")
+    public void updateEs() {
+        articleService.updateEs();
+    }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/document/ArticleDocument.java
+++ b/src/main/java/kr/co/finote/backend/src/article/document/ArticleDocument.java
@@ -56,6 +56,20 @@ public class ArticleDocument {
                 .build();
     }
 
+    public static ArticleDocument of(Article article) {
+        return ArticleDocument.builder()
+                .articleId(article.getId())
+                .title(article.getTitle().trim())
+                .body(article.getBody())
+                .thumbnail(article.getThumbnail())
+                .totalLike(article.getTotalLike())
+                .totalReply(article.getTotalReply())
+                .authorNickname(article.getUser().getNickname())
+                .profileImageUrl(article.getUser().getProfileImageUrl())
+                .createdDate(article.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                .build();
+    }
+
     public void editDocument(Article article) {
         this.title = article.getTitle().trim();
         this.body = article.getBody();

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleEsService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleEsService.java
@@ -123,4 +123,12 @@ public class ArticleEsService {
     public void deleteArticle(Long articleId) {
         articleEsRepository.deleteByArticleId(articleId);
     }
+
+    public void addArticle(Article article) {
+        List<ArticleDocument> articleDocumentList =
+                articleEsRepository.findByArticleId(article.getId());
+        if (articleDocumentList.isEmpty()) {
+            articleEsRepository.save(ArticleDocument.of(article));
+        }
+    }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -293,4 +293,11 @@ public class ArticleService {
     public void editTotalReply(Article article, int num) {
         article.editTotalReply(num);
     }
+
+    public void updateEs() {
+        List<Article> articleList = articleRepository.findAll();
+        for (Article article : articleList) {
+            articleEsService.addArticle(article); // article ES에 추가
+        }
+    }
 }


### PR DESCRIPTION
### ✍🏻 개요
ElasticSearch와 RDB의 싱크를 맞추기위해 DB의 데이터를 강제로 Elasticsearch에 업데이트하는 API를 구현합니다.
해당 API는 Elasticsearch 커텍션 오류로 검색엔진 데이터가 모두 날아갔을경우 사용 가능합니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항


<br>

### 👥 To Reviewers

