### PR TITLE
[FIN-327] feat: Q&A 커뮤니티 질문글 리스트 API

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/argumentresolver/LoginUserArgumentResolver.java
+++ b/src/main/java/kr/co/finote/backend/global/argumentresolver/LoginUserArgumentResolver.java
@@ -2,6 +2,8 @@ package kr.co.finote.backend.global.argumentresolver;
 
 import kr.co.finote.backend.global.annotation.Login;
 import kr.co.finote.backend.global.authentication.PrincipalDetails;
+import kr.co.finote.backend.global.code.ResponseCode;
+import kr.co.finote.backend.global.exception.UnAuthorizedException;
 import kr.co.finote.backend.src.user.domain.User;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
@@ -29,6 +31,9 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
             WebDataBinderFactory binderFactory)
             throws Exception {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication.getPrincipal().equals("anonymousUser")) {
+            throw new UnAuthorizedException(ResponseCode.UNAUTHENTICATED);
+        }
         PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
         return principal.getUser();
     }

--- a/src/main/java/kr/co/finote/backend/src/article/repository/ArticleRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/article/repository/ArticleRepository.java
@@ -1,5 +1,6 @@
 package kr.co.finote.backend.src.article.repository;
 
+import java.util.List;
 import java.util.Optional;
 import kr.co.finote.backend.src.article.domain.Article;
 import kr.co.finote.backend.src.user.domain.User;
@@ -16,6 +17,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     Page<Article> findByUserAndIsDeleted(User user, Boolean isDeleted, Pageable pageable);
 
     Page<Article> findAllByIsDeleted(Boolean isDeleted, Pageable pageable);
+
+    List<Article> findAllByIsDeleted(Boolean isDeleted);
 
     Optional<Article> findByUserAndTitleAndIsDeleted(User user, String title, boolean isDeleted);
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -295,7 +295,7 @@ public class ArticleService {
     }
 
     public void updateEs() {
-        List<Article> articleList = articleRepository.findAll();
+        List<Article> articleList = articleRepository.findAllByIsDeleted(false);
         for (Article article : articleList) {
             articleEsService.addArticle(article); // article ES에 추가
         }

--- a/src/main/java/kr/co/finote/backend/src/qna/api/QuestionApi.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/api/QuestionApi.java
@@ -26,9 +26,9 @@ public class QuestionApi {
 
     @Operation(summary = "질문답변 커뮤니티 메인 페이지", description = "무한 스크롤에 대응하여 결과 제공")
     @GetMapping("/question-list")
-    public QuestionPreviewListResponse mainPage(
+    public QuestionPreviewListResponse questionList(
             @RequestParam int page, @RequestParam(required = false, defaultValue = "30") int size) {
-        return questionService.mainPage(page, size);
+        return questionService.questionList(page, size);
     }
 
     @Operation(summary = "질문글 생성")

--- a/src/main/java/kr/co/finote/backend/src/qna/api/QuestionApi.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/api/QuestionApi.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 import kr.co.finote.backend.global.annotation.Login;
 import kr.co.finote.backend.src.qna.dto.request.PostQuestionRequest;
 import kr.co.finote.backend.src.qna.dto.response.PostQuestionResponse;
+import kr.co.finote.backend.src.qna.dto.response.QuestionPreviewListResponse;
 import kr.co.finote.backend.src.qna.dto.response.QuestionResponse;
 import kr.co.finote.backend.src.qna.service.QuestionService;
 import kr.co.finote.backend.src.user.domain.User;
@@ -22,6 +23,13 @@ import org.springframework.web.bind.annotation.*;
 public class QuestionApi {
 
     QuestionService questionService;
+
+    @Operation(summary = "질문답변 커뮤니티 메인 페이지", description = "무한 스크롤에 대응하여 결과 제공")
+    @GetMapping("/main-page")
+    public QuestionPreviewListResponse mainPage(
+            @RequestParam int page, @RequestParam(required = false, defaultValue = "30") int size) {
+        return questionService.mainPage(page, size);
+    }
 
     @Operation(summary = "질문글 생성")
     @PostMapping("/write")

--- a/src/main/java/kr/co/finote/backend/src/qna/api/QuestionApi.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/api/QuestionApi.java
@@ -25,7 +25,7 @@ public class QuestionApi {
     QuestionService questionService;
 
     @Operation(summary = "질문답변 커뮤니티 메인 페이지", description = "무한 스크롤에 대응하여 결과 제공")
-    @GetMapping("/main-page")
+    @GetMapping("/question-list")
     public QuestionPreviewListResponse mainPage(
             @RequestParam int page, @RequestParam(required = false, defaultValue = "30") int size) {
         return questionService.mainPage(page, size);

--- a/src/main/java/kr/co/finote/backend/src/qna/dto/response/QuestionPreviewListResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/dto/response/QuestionPreviewListResponse.java
@@ -1,0 +1,26 @@
+package kr.co.finote.backend.src.qna.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class QuestionPreviewListResponse {
+
+    private int page;
+    private int size;
+
+    private List<QuestionPreviewResponse> questionList;
+
+    public static QuestionPreviewListResponse createdQuestionPreviewListResponse(
+            int page, int size, List<QuestionPreviewResponse> questionList) {
+        return QuestionPreviewListResponse.builder()
+                .page(page)
+                .size(size)
+                .questionList(questionList)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/qna/dto/response/QuestionPreviewResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/dto/response/QuestionPreviewResponse.java
@@ -1,0 +1,35 @@
+package kr.co.finote.backend.src.qna.dto.response;
+
+import java.time.format.DateTimeFormatter;
+import kr.co.finote.backend.src.qna.domain.Question;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuestionPreviewResponse {
+
+    private Long id;
+
+    private String title;
+    private String authorNickname;
+    private String profileImageUrl;
+    private String createdDate;
+
+    private int totalAnswer;
+
+    public static QuestionPreviewResponse of(Question question) {
+        return QuestionPreviewResponse.builder()
+                .id(question.getId())
+                .title(question.getTitle())
+                .authorNickname(question.getUser().getNickname())
+                .profileImageUrl(question.getUser().getProfileImageUrl())
+                .createdDate(question.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                .totalAnswer(question.getTotalAnswer())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/qna/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/repository/QuestionRepository.java
@@ -1,13 +1,19 @@
 package kr.co.finote.backend.src.qna.repository;
 
+import java.util.List;
 import java.util.Optional;
 import kr.co.finote.backend.src.qna.domain.Question;
 import kr.co.finote.backend.src.user.domain.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     Optional<Question> findByUserAndTitleAndIsDeleted(User user, String title, boolean isDeleted);
 
     Optional<Question> findByIdAndIsDeleted(Long questionId, boolean isDeleted);
+
+    @Query("select q from Question q join fetch q.user where q.isDeleted = false")
+    List<Question> findAllByIsDeleted(Boolean isDeleted, Pageable pageable);
 }

--- a/src/main/java/kr/co/finote/backend/src/qna/service/QuestionEsService.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/service/QuestionEsService.java
@@ -2,23 +2,40 @@ package kr.co.finote.backend.src.qna.service;
 
 import java.util.List;
 import kr.co.finote.backend.global.code.ResponseCode;
+import kr.co.finote.backend.global.exception.ConnectException;
 import kr.co.finote.backend.global.exception.NotFoundException;
 import kr.co.finote.backend.src.qna.document.QuestionDocument;
 import kr.co.finote.backend.src.qna.domain.Question;
 import kr.co.finote.backend.src.qna.repository.QuestionEsRepository;
 import kr.co.finote.backend.src.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class QuestionEsService {
 
     private final QuestionEsRepository questionEsRepository;
 
-    public void saveDocument(Question question, User user) {
-        QuestionDocument questionDocument = QuestionDocument.createQuestionDocument(question, user);
-        questionEsRepository.save(questionDocument);
+    private final int MAX_CALL_COUNT = 3;
+
+    public void save(Question question, User user) {
+        int callCount = 0;
+        boolean isSaved = false;
+
+        while (callCount < MAX_CALL_COUNT) {
+            callCount += 1;
+            try {
+                questionEsRepository.save(QuestionDocument.createQuestionDocument(question, user));
+                isSaved = true;
+                break;
+            } catch (Exception e) {
+                log.info("Save Question Document : {}", callCount);
+            }
+        }
+        if (!isSaved) throw new ConnectException(ResponseCode.ES_NOT_CONNECT);
     }
 
     public void editDocumentByQuestion(Question question) {

--- a/src/main/java/kr/co/finote/backend/src/qna/service/QuestionService.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/service/QuestionService.java
@@ -1,18 +1,24 @@
 package kr.co.finote.backend.src.qna.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import kr.co.finote.backend.global.code.ResponseCode;
-import kr.co.finote.backend.global.exception.ConnectException;
 import kr.co.finote.backend.global.exception.InvalidInputException;
 import kr.co.finote.backend.global.exception.NotFoundException;
 import kr.co.finote.backend.src.qna.domain.Question;
 import kr.co.finote.backend.src.qna.dto.request.PostQuestionRequest;
 import kr.co.finote.backend.src.qna.dto.response.PostQuestionResponse;
+import kr.co.finote.backend.src.qna.dto.response.QuestionPreviewListResponse;
+import kr.co.finote.backend.src.qna.dto.response.QuestionPreviewResponse;
 import kr.co.finote.backend.src.qna.dto.response.QuestionResponse;
 import kr.co.finote.backend.src.qna.repository.QuestionRepository;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,27 +32,12 @@ public class QuestionService {
 
     private final UserService userService;
 
-    private final int MAX_CALL_COUNT = 3;
-
     @Transactional
     public PostQuestionResponse postQuestion(User author, PostQuestionRequest request) {
         isDuplicatedTitle(author, request);
-
-        int callCount = 0;
-        boolean isSaved = false;
         Question savedQuestion = questionRepository.save(Question.createQuestion(author, request));
 
-        while (callCount < MAX_CALL_COUNT) {
-            callCount += 1;
-            try {
-                questionEsService.saveDocument(savedQuestion, author);
-                isSaved = true;
-                break;
-            } catch (Exception e) {
-                log.info("Save Question Document : {}", callCount);
-            }
-        }
-        if (!isSaved) throw new ConnectException(ResponseCode.ES_NOT_CONNECT);
+        questionEsService.save(savedQuestion, author);
 
         return PostQuestionResponse.of(author, savedQuestion);
     }
@@ -94,6 +85,36 @@ public class QuestionService {
 
         question.delete();
         questionEsService.deleteDocument(question.getId());
+    }
+
+    public QuestionPreviewListResponse mainPage(int page, int size) {
+        int pageNum = page - 1;
+        Pageable pageable = PageRequest.of(pageNum, size, mainPageSort());
+
+        List<Question> contents = questionRepository.findAllByIsDeleted(false, pageable);
+
+        List<QuestionPreviewResponse> questionPreviewResponseList =
+                ToQuestionPreviewResponses(contents);
+
+        return QuestionPreviewListResponse.createdQuestionPreviewListResponse(
+                page, size, questionPreviewResponseList);
+    }
+
+    private Sort mainPageSort() {
+        return Sort.by(Sort.Order.desc("totalAnswer"), Sort.Order.desc("createdDate"));
+    }
+
+    private List<QuestionPreviewResponse> ToQuestionPreviewResponses(List<?> list) {
+        List<QuestionPreviewResponse> questionPreviewResponseList = new ArrayList<>();
+
+        for (Object object : list) {
+            if (object instanceof Question) {
+                Question question = (Question) object;
+                questionPreviewResponseList.add(QuestionPreviewResponse.of(question));
+            }
+        }
+
+        return questionPreviewResponseList;
     }
 
     private static void checkQuestionAuthority(User loginUser, Question question) {

--- a/src/main/java/kr/co/finote/backend/src/qna/service/QuestionService.java
+++ b/src/main/java/kr/co/finote/backend/src/qna/service/QuestionService.java
@@ -87,7 +87,7 @@ public class QuestionService {
         questionEsService.deleteDocument(question.getId());
     }
 
-    public QuestionPreviewListResponse mainPage(int page, int size) {
+    public QuestionPreviewListResponse questionList(int page, int size) {
         int pageNum = page - 1;
         Pageable pageable = PageRequest.of(pageNum, size, mainPageSort());
 


### PR DESCRIPTION
### ✍🏻 개요
Q&A 커뮤니티의 메인 페이지는 트렌딩 아티클과 유사하게 무한 스크롤 방식의 질문글 리스트를 제공합니다.
이 때 필요한 정렬 기준과, 무한 스크롤 대응을 수행합니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 무한 스크롤 대응 API 작성
- N+1 문제 해결을 위해 Native Query 작성


<br>

### 👥 To Reviewers
공유하고 싶은 부분은 별도로 comment 달아놓겠습니다.
