### PR TITLE
hotfix: 댓글 목록에서 삭제된 것까지 보여주는 문제 해결

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/repository/ReplyRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/article/repository/ReplyRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
-    @Query("select r from Reply r join fetch r.user where r.article = :article")
+    @Query(
+            "select r from Reply r join fetch r.user where r.article = :article and r.isDeleted = false")
     List<Reply> findAllWithArticle(@Param("article") Article article);
 }


### PR DESCRIPTION
### ✍🏻 개요
블로그 글에 대한 댓글 목록 조회 API에서 삭제된 댓글까지 보여주는 문제가 있습니다. 이를 해결합니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- query에 isdeleted=false 절 추가

<br>

### 👥 To Reviewers
리뷰어들에게 하고 싶은 말을 남기세요.(주로 리뷰 받기를 원하는 곳 등)
