### PR TITLE
[FIN-390] feat: 카테고리 수정 및 삭제 API

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
+++ b/src/main/java/kr/co/finote/backend/global/code/ResponseCode.java
@@ -29,7 +29,12 @@ public enum ResponseCode {
     EMAIL_ALREADY_EXIST(BAD_REQUEST, "400_EMAIL_ALREADY_EXIST", "해당 이메일로 가입된 계정이 존재합니다."),
     EMAIL_NOT_VERIFIED(BAD_REQUEST, "400_NOT_VERIFIED_EMAIL", "인증되지 않은 이메일입니다."),
     EMAIL_CODE_NOT_MATCH(BAD_REQUEST, "400_EMAIL_CODE_NOT_MATCH", "인증 코드가 일치하지 않습니다."),
+
+    /** category error */
     CATEGORY_ALREADY_EXIST(BAD_REQUEST, "400_CATEGORY_ALREADY_EXIST", "같은 이름의 카테고리가 이미 존재합니다."),
+    CATEGORY_NOT_FOUND(NOT_FOUND, "404_CATEGORY_NOT_FOUND", "해당 카테고리를 찾을 수 없습니다."),
+    CATEGORY_NOT_WRITER(BAD_REQUEST, "400_CATEGORY_NOT_WRITER", "카테고리 수정 및 삭제 권한이 없습니다."),
+    CATEGORY_NOT_EMPTY(BAD_REQUEST, "400_CATEGORY_NOT_EMPTY", "카테고리에 게시글이 존재합니다."),
 
     /** article error */
     ARTICLE_NOT_FOUND(NOT_FOUND, "404_ARTICLE_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."),

--- a/src/main/java/kr/co/finote/backend/src/article/repository/ArticleRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/article/repository/ArticleRepository.java
@@ -3,6 +3,7 @@ package kr.co.finote.backend.src.article.repository;
 import java.util.List;
 import java.util.Optional;
 import kr.co.finote.backend.src.article.domain.Article;
+import kr.co.finote.backend.src.user.domain.Category;
 import kr.co.finote.backend.src.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,4 +22,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     List<Article> findAllByIsDeleted(Boolean isDeleted);
 
     Optional<Article> findByUserAndTitleAndIsDeleted(User user, String title, boolean isDeleted);
+
+    boolean existsByCategoryAndIsDeleted(Category category, boolean isDeleted);
 }

--- a/src/main/java/kr/co/finote/backend/src/article/repository/ReplyRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/article/repository/ReplyRepository.java
@@ -12,6 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
     @Query(
-            "select r from Reply r join fetch r.user where r.article = :article and r.isDeleted = false order by r.createdDate asc")
+            "select r from Reply r join fetch r.user where r.article = :article and r.isDeleted = false order by r.createdDate")
     List<Reply> findAllWithArticle(@Param("article") Article article);
 }

--- a/src/main/java/kr/co/finote/backend/src/article/repository/ReplyRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/article/repository/ReplyRepository.java
@@ -12,6 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
     @Query(
-            "select r from Reply r join fetch r.user where r.article = :article and r.isDeleted = false")
+            "select r from Reply r join fetch r.user where r.article = :article and r.isDeleted = false order by r.createdDate asc")
     List<Reply> findAllWithArticle(@Param("article") Article article);
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -19,6 +19,7 @@ import kr.co.finote.backend.src.article.dto.request.ArticleRequest;
 import kr.co.finote.backend.src.article.dto.request.DragArticleRequest;
 import kr.co.finote.backend.src.article.dto.response.*;
 import kr.co.finote.backend.src.article.repository.ArticleRepository;
+import kr.co.finote.backend.src.user.domain.Category;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -299,5 +300,9 @@ public class ArticleService {
         for (Article article : articleList) {
             articleEsService.addArticle(article); // article ES에 추가
         }
+    }
+
+    public boolean existsByCategory(Category category) {
+        return articleRepository.existsByCategoryAndIsDeleted(category, false);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
@@ -118,4 +118,19 @@ public class UserApi {
             @Login User loginUser, @RequestBody @Valid CategoryRequest request) {
         return categoryService.addCategory(loginUser, request);
     }
+
+    @Operation(summary = "카테고리 수정")
+    @PostMapping("/categories/edit/{category-id}")
+    public CategoryResponse editCategory(
+            @Login User loginUser,
+            @PathVariable("category-id") Long categoryId,
+            @RequestBody @Valid CategoryRequest request) {
+        return categoryService.editCategory(loginUser, categoryId, request);
+    }
+
+    @Operation(summary = "카테고리 삭제")
+    @PostMapping("/categories/delete/{category-id}")
+    public void deleteCategory(@Login User loginUser, @PathVariable("category-id") Long categoryId) {
+        categoryService.deleteCategory(loginUser, categoryId);
+    }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/domain/Category.java
+++ b/src/main/java/kr/co/finote/backend/src/user/domain/Category.java
@@ -27,4 +27,12 @@ public class Category extends BaseEntity {
     public static Category createCategory(User user, String name) {
         return Category.builder().user(user).name(name).build();
     }
+
+    public void editCategory(String name) {
+        this.name = name;
+    }
+
+    public void deleteCategory() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/repository/CategoryRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/user/repository/CategoryRepository.java
@@ -1,5 +1,6 @@
 package kr.co.finote.backend.src.user.repository;
 
+import java.util.Optional;
 import kr.co.finote.backend.src.user.domain.Category;
 import kr.co.finote.backend.src.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +8,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    Optional<Category> findByIdAndIsDeleted(Long id, Boolean isDeleted);
 
     boolean existsByNameAndUserAndIsDeleted(String name, User user, Boolean isDeleted);
 }

--- a/src/main/java/kr/co/finote/backend/src/user/service/CategoryService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/CategoryService.java
@@ -2,6 +2,8 @@ package kr.co.finote.backend.src.user.service;
 
 import kr.co.finote.backend.global.code.ResponseCode;
 import kr.co.finote.backend.global.exception.InvalidInputException;
+import kr.co.finote.backend.global.exception.NotFoundException;
+import kr.co.finote.backend.src.article.service.ArticleService;
 import kr.co.finote.backend.src.user.domain.Category;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.dto.request.CategoryRequest;
@@ -17,6 +19,8 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
 
+    private final ArticleService articleService;
+
     @Transactional
     public CategoryResponse addCategory(User loginUser, CategoryRequest request) {
         isDuplicate(loginUser, request);
@@ -30,6 +34,39 @@ public class CategoryService {
                 categoryRepository.existsByNameAndUserAndIsDeleted(request.getName(), loginUser, false);
         if (exists) {
             throw new InvalidInputException(ResponseCode.CATEGORY_ALREADY_EXIST);
+        }
+    }
+
+    @Transactional
+    public CategoryResponse editCategory(User loginUser, Long categoryId, CategoryRequest request) {
+        Category category = findById(categoryId);
+        checkCategoryAuthority(loginUser, category);
+        category.editCategory(request.getName());
+        return CategoryResponse.of(category);
+    }
+
+    @Transactional
+    public void deleteCategory(User loginUser, Long categoryId) {
+        Category category = findById(categoryId);
+        checkCategoryAuthority(loginUser, category);
+        checkCategoryIsEmpty(category); // 카테고리에 글이 존재할 경우 삭제하지 못함
+        category.deleteCategory();
+    }
+
+    private Category findById(Long categoryId) {
+        return categoryRepository
+                .findById(categoryId)
+                .orElseThrow(() -> new NotFoundException(ResponseCode.CATEGORY_NOT_FOUND));
+    }
+
+    private void checkCategoryIsEmpty(Category category) {
+        if (articleService.existsByCategory(category))
+            throw new InvalidInputException(ResponseCode.CATEGORY_NOT_EMPTY);
+    }
+
+    private static void checkCategoryAuthority(User loginUser, Category category) {
+        if (!loginUser.getEmail().equals(category.getUser().getEmail())) {
+            throw new InvalidInputException(ResponseCode.CATEGORY_NOT_WRITER);
         }
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/service/CategoryService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/CategoryService.java
@@ -55,7 +55,7 @@ public class CategoryService {
 
     private Category findById(Long categoryId) {
         return categoryRepository
-                .findById(categoryId)
+                .findByIdAndIsDeleted(categoryId, false)
                 .orElseThrow(() -> new NotFoundException(ResponseCode.CATEGORY_NOT_FOUND));
     }
 


### PR DESCRIPTION
### ✍🏻 개요
유저가 자신의 카테고리를 수정하고 삭제할 수 있습니다. 이때 글이 존재하는 카테고리는 삭제할 수 없습니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 카테고리 수정 및 삭제 API 구현
- 동일 유저가 중복 카테고리 생성 방지
- 글이 존재하는 카테고리 삭제 불가

<br>

### 👥 To Reviewers

