### PR TITLE
[FIN-349] feat: 카테고리 목록 API

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/repository/ArticleRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/article/repository/ArticleRepository.java
@@ -25,7 +25,5 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     boolean existsByCategoryAndIsDeleted(Category category, boolean isDeleted);
 
-    int countAllByCategoryAndIsDeleted(Category category, boolean isDeleted);
-
-    int countAllByCategoryAndUserAndIsDeleted(Category category, User user, boolean isDeleted);
+    Long countAllByCategoryAndUserAndIsDeleted(Category category, User user, boolean isDeleted);
 }

--- a/src/main/java/kr/co/finote/backend/src/article/repository/ArticleRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/article/repository/ArticleRepository.java
@@ -26,4 +26,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     boolean existsByCategoryAndIsDeleted(Category category, boolean isDeleted);
 
     int countAllByCategoryAndIsDeleted(Category category, boolean isDeleted);
+
+    int countAllByCategoryAndUserAndIsDeleted(Category category, User user, boolean isDeleted);
 }

--- a/src/main/java/kr/co/finote/backend/src/article/repository/ArticleRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/article/repository/ArticleRepository.java
@@ -24,4 +24,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     Optional<Article> findByUserAndTitleAndIsDeleted(User user, String title, boolean isDeleted);
 
     boolean existsByCategoryAndIsDeleted(Category category, boolean isDeleted);
+
+    int countAllByCategoryAndIsDeleted(Category category, boolean isDeleted);
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -306,7 +306,7 @@ public class ArticleService {
         return articleRepository.existsByCategoryAndIsDeleted(category, false);
     }
 
-    public int countByCategory(Category category) {
-        return articleRepository.countAllByCategoryAndIsDeleted(category, false);
+    public int countByCategoryAndUser(Category category, User loginUser) {
+        return articleRepository.countAllByCategoryAndUserAndIsDeleted(category, loginUser, false);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -306,7 +306,7 @@ public class ArticleService {
         return articleRepository.existsByCategoryAndIsDeleted(category, false);
     }
 
-    public int countByCategoryAndUser(Category category, User loginUser) {
+    public Long countByCategoryAndUser(Category category, User loginUser) {
         return articleRepository.countAllByCategoryAndUserAndIsDeleted(category, loginUser, false);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
+++ b/src/main/java/kr/co/finote/backend/src/article/service/ArticleService.java
@@ -305,4 +305,8 @@ public class ArticleService {
     public boolean existsByCategory(Category category) {
         return articleRepository.existsByCategoryAndIsDeleted(category, false);
     }
+
+    public int countByCategory(Category category) {
+        return articleRepository.countAllByCategoryAndIsDeleted(category, false);
+    }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
+++ b/src/main/java/kr/co/finote/backend/src/user/api/UserApi.java
@@ -112,16 +112,23 @@ public class UserApi {
         return articleLikeService.getLikeArticles(loginUser, page, size);
     }
 
+    /** category * */
+    @Operation(summary = "카테고리 목록")
+    @GetMapping("/categories")
+    public CategoryListResponse getCategories(@Login User loginUser) {
+        return categoryService.getCategories(loginUser);
+    }
+
     @Operation(summary = "카테고리 생성")
     @PostMapping("/categories/add")
-    public CategoryResponse addCategory(
+    public PostCategoryResponse addCategory(
             @Login User loginUser, @RequestBody @Valid CategoryRequest request) {
         return categoryService.addCategory(loginUser, request);
     }
 
     @Operation(summary = "카테고리 수정")
     @PostMapping("/categories/edit/{category-id}")
-    public CategoryResponse editCategory(
+    public PostCategoryResponse editCategory(
             @Login User loginUser,
             @PathVariable("category-id") Long categoryId,
             @RequestBody @Valid CategoryRequest request) {

--- a/src/main/java/kr/co/finote/backend/src/user/dto/response/CategoryListResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/response/CategoryListResponse.java
@@ -10,7 +10,8 @@ public class CategoryListResponse {
 
     private List<CategoryResponse> categoryResponseList;
 
-    public static CategoryListResponse of(List<CategoryResponse> categoryResponseList) {
+    public static CategoryListResponse createCategoryListResponse(
+            List<CategoryResponse> categoryResponseList) {
         return new CategoryListResponse(categoryResponseList);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/dto/response/CategoryListResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/response/CategoryListResponse.java
@@ -1,0 +1,16 @@
+package kr.co.finote.backend.src.user.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CategoryListResponse {
+
+    private List<CategoryResponse> categoryResponseList;
+
+    public static CategoryListResponse of(List<CategoryResponse> categoryResponseList) {
+        return new CategoryListResponse(categoryResponseList);
+    }
+}

--- a/src/main/java/kr/co/finote/backend/src/user/dto/response/CategoryResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/response/CategoryResponse.java
@@ -3,16 +3,18 @@ package kr.co.finote.backend.src.user.dto.response;
 import kr.co.finote.backend.src.user.domain.Category;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class CategoryResponse {
 
     private Long id;
     private String name;
-    private int totalArticles;
+    private Long totalArticles;
 
-    public static CategoryResponse of(Category category, int totalArticles) {
+    public static CategoryResponse of(Category category, Long totalArticles) {
         return new CategoryResponse(category.getId(), category.getName(), totalArticles);
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/dto/response/PostCategoryResponse.java
+++ b/src/main/java/kr/co/finote/backend/src/user/dto/response/PostCategoryResponse.java
@@ -6,13 +6,12 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class CategoryResponse {
+public class PostCategoryResponse {
 
     private Long id;
     private String name;
-    private int totalArticles;
 
-    public static CategoryResponse of(Category category, int totalArticles) {
-        return new CategoryResponse(category.getId(), category.getName(), totalArticles);
+    public static PostCategoryResponse of(Category category) {
+        return new PostCategoryResponse(category.getId(), category.getName());
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/user/repository/CategoryRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/user/repository/CategoryRepository.java
@@ -15,4 +15,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     boolean existsByNameAndUserAndIsDeleted(String name, User user, Boolean isDeleted);
 
     List<Category> findAllByUserAndIsDeletedOrderByCreatedDate(User user, Boolean isDeleted);
+
+    Optional<Category> findByNameAndIsDeleted(String name, Boolean isDeleted);
 }

--- a/src/main/java/kr/co/finote/backend/src/user/repository/CategoryRepository.java
+++ b/src/main/java/kr/co/finote/backend/src/user/repository/CategoryRepository.java
@@ -1,5 +1,6 @@
 package kr.co.finote.backend.src.user.repository;
 
+import java.util.List;
 import java.util.Optional;
 import kr.co.finote.backend.src.user.domain.Category;
 import kr.co.finote.backend.src.user.domain.User;
@@ -12,4 +13,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByIdAndIsDeleted(Long id, Boolean isDeleted);
 
     boolean existsByNameAndUserAndIsDeleted(String name, User user, Boolean isDeleted);
+
+    List<Category> findAllByUserAndIsDeletedOrderByCreatedDate(User user, Boolean isDeleted);
 }

--- a/src/main/java/kr/co/finote/backend/src/user/service/CategoryService.java
+++ b/src/main/java/kr/co/finote/backend/src/user/service/CategoryService.java
@@ -1,5 +1,7 @@
 package kr.co.finote.backend.src.user.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import kr.co.finote.backend.global.code.ResponseCode;
 import kr.co.finote.backend.global.exception.InvalidInputException;
 import kr.co.finote.backend.global.exception.NotFoundException;
@@ -7,9 +9,12 @@ import kr.co.finote.backend.src.article.service.ArticleService;
 import kr.co.finote.backend.src.user.domain.Category;
 import kr.co.finote.backend.src.user.domain.User;
 import kr.co.finote.backend.src.user.dto.request.CategoryRequest;
+import kr.co.finote.backend.src.user.dto.response.CategoryListResponse;
 import kr.co.finote.backend.src.user.dto.response.CategoryResponse;
+import kr.co.finote.backend.src.user.dto.response.PostCategoryResponse;
 import kr.co.finote.backend.src.user.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,11 +27,11 @@ public class CategoryService {
     private final ArticleService articleService;
 
     @Transactional
-    public CategoryResponse addCategory(User loginUser, CategoryRequest request) {
+    public PostCategoryResponse addCategory(User loginUser, CategoryRequest request) {
         isDuplicate(loginUser, request);
         Category category = Category.createCategory(loginUser, request.getName());
         Category saveCategory = categoryRepository.save(category);
-        return CategoryResponse.of(saveCategory);
+        return PostCategoryResponse.of(saveCategory);
     }
 
     private void isDuplicate(User loginUser, CategoryRequest request) {
@@ -38,11 +43,12 @@ public class CategoryService {
     }
 
     @Transactional
-    public CategoryResponse editCategory(User loginUser, Long categoryId, CategoryRequest request) {
+    public PostCategoryResponse editCategory(
+            User loginUser, Long categoryId, CategoryRequest request) {
         Category category = findById(categoryId);
         checkCategoryAuthority(loginUser, category);
         category.editCategory(request.getName());
-        return CategoryResponse.of(category);
+        return PostCategoryResponse.of(category);
     }
 
     @Transactional
@@ -68,5 +74,26 @@ public class CategoryService {
         if (!loginUser.getEmail().equals(category.getUser().getEmail())) {
             throw new InvalidInputException(ResponseCode.CATEGORY_NOT_WRITER);
         }
+    }
+
+    public CategoryListResponse getCategories(User loginUser) {
+        List<Category> categoryList = categoryRepository.findAllByUserAndIsDeletedOrderByCreatedDate(loginUser, false);
+        List<CategoryResponse> categoryResponseList = toCategoryResponseList(categoryList);
+        return CategoryListResponse.of(categoryResponseList);
+    }
+
+    @NotNull
+    private List<CategoryResponse> toCategoryResponseList(List<Category> categoryList) {
+        return categoryList.stream()
+                .map(
+                        category -> {
+                            int totalArticles = getTotalArticles(category);
+                            return CategoryResponse.of(category, totalArticles);
+                        })
+                .collect(Collectors.toList());
+    }
+
+    private int getTotalArticles(Category category) {
+        return articleService.countByCategory(category);
     }
 }


### PR DESCRIPTION
### ✍🏻 개요
유저가 자신의 카테고리 목록을 관리하기 위해 카테고리 목록 정보를 확인할 수 있는 API를 호출합니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- 카테고리 목록 및 해당 카테고리 속한 글의 수
- 기타 카테고리 및 유저가 직접 생성한 카테고리 정보

<br>

### 👥 To Reviewers

