### PR TITLE
hotfix: 유저 인증을 위한 URL 검증 로직 수정

### DIFF
--- a/src/main/java/kr/co/finote/backend/global/argumentresolver/LoginUserArgumentResolver.java
+++ b/src/main/java/kr/co/finote/backend/global/argumentresolver/LoginUserArgumentResolver.java
@@ -2,8 +2,6 @@ package kr.co.finote.backend.global.argumentresolver;
 
 import kr.co.finote.backend.global.annotation.Login;
 import kr.co.finote.backend.global.authentication.PrincipalDetails;
-import kr.co.finote.backend.global.code.ResponseCode;
-import kr.co.finote.backend.global.exception.UnAuthorizedException;
 import kr.co.finote.backend.src.user.domain.User;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
@@ -31,9 +29,6 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
             WebDataBinderFactory binderFactory)
             throws Exception {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication.getPrincipal().equals("anonymousUser")) {
-            throw new UnAuthorizedException(ResponseCode.UNAUTHENTICATED);
-        }
         PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
         return principal.getUser();
     }

--- a/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
+++ b/src/main/java/kr/co/finote/backend/global/config/SecurityConfig.java
@@ -40,7 +40,14 @@ public class SecurityConfig {
     @Value("${QNA_URLS}")
     private String[] qnaUrls;
 
+    @Value("${ANSWER_URLS}")
+    private String[] answerUrls;
+
+    @Value("${REPLY_URLS}")
+    private String[] replyUrls;
+
     private final JwtTokenProvider jwtTokenProvider;
+
     private final JwtService jwtService;
 
     @Bean
@@ -65,6 +72,10 @@ public class SecurityConfig {
                 .antMatchers(commonUrls)
                 .authenticated()
                 .antMatchers(qnaUrls)
+                .authenticated()
+                .antMatchers(answerUrls)
+                .authenticated()
+                .antMatchers(replyUrls)
                 .authenticated()
                 .anyRequest()
                 .permitAll()


### PR DESCRIPTION
### ✍🏻 개요
특정 검증 URL에 대해서 Spring security filter에서 처리되지 못하고, RestController까지 요청이 전달되는 문제가 발생되었습니다.
이에 따라 잘못된 검증 URL 목록을 수정하였고, URL목록을 도메인 별로 나누어 SecurityConfig가 일부 수정되었습니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항
- Security filter 이후의 불필요한 예외처리 제거
- 검증이 필요한 URL은 반드시 Security filter 통과하도록 변경

<br>

### 👥 To Reviewers
application.properties의 값은 팀 채널에 남겨두었습니다.
