### PR TITLE
[FIN-423] feat:피드 서비스 팬아웃 구현

### DIFF
--- a/src/main/java/kr/co/finote/backend/src/article/dto/request/FeedRequest.java
+++ b/src/main/java/kr/co/finote/backend/src/article/dto/request/FeedRequest.java
@@ -1,10 +1,14 @@
 package kr.co.finote.backend.src.article.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class FeedRequest {
 
     private String authorId;

--- a/src/main/java/kr/co/finote/backend/src/common/service/FeedService.java
+++ b/src/main/java/kr/co/finote/backend/src/common/service/FeedService.java
@@ -3,6 +3,7 @@ package kr.co.finote.backend.src.common.service;
 import com.amazonaws.services.sqs.model.SendMessageResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import kr.co.finote.backend.src.article.dto.request.FeedRequest;
 import kr.co.finote.backend.src.common.domain.FollowInfo;
 import kr.co.finote.backend.src.common.utils.SqsSender;
@@ -14,8 +15,6 @@ import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/kr/co/finote/backend/src/common/service/FeedService.java
+++ b/src/main/java/kr/co/finote/backend/src/common/service/FeedService.java
@@ -2,18 +2,46 @@ package kr.co.finote.backend.src.common.service;
 
 import com.amazonaws.services.sqs.model.SendMessageResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.finote.backend.src.article.dto.request.FeedRequest;
+import kr.co.finote.backend.src.common.domain.FollowInfo;
 import kr.co.finote.backend.src.common.utils.SqsSender;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.aws.messaging.listener.Acknowledgment;
+import org.springframework.cloud.aws.messaging.listener.SqsMessageDeletionPolicy;
+import org.springframework.cloud.aws.messaging.listener.annotation.SqsListener;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class FeedService {
 
     private final SqsSender sqsSender;
+    private final FollowService followService;
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     public SendMessageResult publish(FeedRequest request) throws JsonProcessingException {
         return sqsSender.sendMessage(request);
+    }
+
+    @SqsListener(value = "${QUEUE_NAME}", deletionPolicy = SqsMessageDeletionPolicy.NEVER)
+    public void fanout(@Payload String info, Acknowledgment ack) throws JsonProcessingException {
+        FeedRequest request = objectMapper.readValue(info, FeedRequest.class);
+
+        List<FollowInfo> followInfos = followService.followersByAuthorId(request.getAuthorId());
+        ListOperations<String, Object> listOps = redisTemplate.opsForList();
+
+        for (FollowInfo followInfo : followInfos) {
+            String key = followInfo.getFromUser().getId() + ":feed";
+            listOps.leftPush(key, request.getArticleId());
+        }
+
+        ack.acknowledge();
     }
 }

--- a/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
+++ b/src/main/java/kr/co/finote/backend/src/common/service/FollowService.java
@@ -126,6 +126,11 @@ public class FollowService {
         return FollowerCheckResponse.createFollowerCheckResponse(isFollowed);
     }
 
+    public List<FollowInfo> followersByAuthorId(String authorId) {
+        User author = userService.findById(authorId);
+        return followInfoRepository.findAllWithToUser(author);
+    }
+
     private List<FollowUserResponse> FollowerUserList(List<FollowInfo> followInfos) {
         return followInfos.stream()
                 .map(followInfo -> FollowUserResponse.of(followInfo.getFromUser()))


### PR DESCRIPTION
### ✍🏻 개요
피드 기능에서 글 작성자의 모든 팔로워에게 이벤트를 전송하는 팬아웃 기능을 구현합니다.

<br>

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링

<br>

### ❓ 변경 사항

<br>

### 👥 To Reviewers
구현 과정은 해당 [노션 링크](https://www.notion.so/soma-meteor/Message-Queue-aeb2a06d55ef4b4fa689dea1ebc3fa91?pvs=4) 를 참고해주세요. 그리고 Dev-api yml, properties 파일 수정해두었습니다.